### PR TITLE
Harden auth sign-in flow

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -19,6 +19,23 @@ async function body(response: Response) {
   return response.json() as Promise<Record<string, any>>;
 }
 
+function createSessionKv(seed: Record<string, string> = {}) {
+  const store = new Map(Object.entries(seed));
+  const kv = {
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async put(key: string, value: string | ArrayBuffer | ArrayBufferView | ReadableStream) {
+      store.set(key, String(value));
+    },
+    async delete(key: string) {
+      store.delete(key);
+    }
+  };
+
+  return Object.assign(kv, { store }) as unknown as KVNamespace & { store: Map<string, string> };
+}
+
 describe("API router regression coverage", () => {
   let repository: InMemoryRepository;
   let jobs: RecordingJobQueue;
@@ -60,6 +77,207 @@ describe("API router regression coverage", () => {
       { repository, jobs }
     );
     expect((await body(token)).token_type).toBe("Bearer");
+  });
+
+  it("fails closed for oauth start when credentials or session KV are missing", async () => {
+    const missingSecret = await handleRequest(
+      request("/api/auth/google/start?return_to=/"),
+      {
+        ...env,
+        AUTH_MODE: "oauth",
+        GOOGLE_CLIENT_ID: "google-client",
+        SESSION_KV: createSessionKv()
+      },
+      { repository, jobs }
+    );
+    const missingSecretPayload = await body(missingSecret);
+
+    expect(missingSecret.status).toBe(503);
+    expect(missingSecretPayload.error.code).toBe("auth_not_configured");
+    expect(missingSecretPayload.error.details.missing).toContain("GOOGLE_CLIENT_SECRET");
+    expect(missingSecretPayload.authorization_url).toBeUndefined();
+
+    const missingKv = await handleRequest(
+      request("/api/auth/x/start?return_to=/"),
+      {
+        ...env,
+        AUTH_MODE: "oauth",
+        X_CLIENT_ID: "x-client",
+        X_CLIENT_SECRET: "x-secret"
+      },
+      { repository, jobs }
+    );
+    const missingKvPayload = await body(missingKv);
+
+    expect(missingKv.status).toBe(503);
+    expect(missingKvPayload.error.code).toBe("auth_not_configured");
+    expect(missingKvPayload.error.details.missing).toContain("SESSION_KV");
+    expect(missingKvPayload.authorization_url).toBeUndefined();
+  });
+
+  it("validates and consumes oauth callback state before returning not implemented", async () => {
+    const sessionKv = createSessionKv();
+    const oauthEnv: Env = {
+      ...env,
+      AUTH_MODE: "oauth",
+      GOOGLE_CLIENT_ID: "google-client",
+      GOOGLE_CLIENT_SECRET: "google-secret",
+      SESSION_KV: sessionKv
+    };
+
+    const start = await body(
+      await handleRequest(request("/api/auth/google/start?return_to=/after-auth"), oauthEnv, { repository, jobs })
+    );
+    expect(start.authorization_url).toContain("accounts.google.com");
+    expect(sessionKv.store.has(`oauth_state:${start.state}`)).toBe(true);
+
+    const missingCode = await handleRequest(request(`/api/auth/google/callback?state=${start.state}`), oauthEnv, {
+      repository,
+      jobs
+    });
+    expect(missingCode.status).toBe(400);
+    expect((await body(missingCode)).error.code).toBe("oauth_code_required");
+    expect(sessionKv.store.has(`oauth_state:${start.state}`)).toBe(true);
+
+    const invalidState = await handleRequest(request("/api/auth/google/callback?state=missing&code=auth-code"), oauthEnv, {
+      repository,
+      jobs
+    });
+    expect(invalidState.status).toBe(400);
+    expect((await body(invalidState)).error.code).toBe("invalid_oauth_state");
+
+    const firstCallback = await handleRequest(
+      request(`/api/auth/google/callback?state=${start.state}&code=auth-code`),
+      oauthEnv,
+      { repository, jobs }
+    );
+    expect(firstCallback.status).toBe(501);
+    expect((await body(firstCallback)).error.code).toBe("not_implemented");
+    expect(sessionKv.store.has(`oauth_state:${start.state}`)).toBe(false);
+
+    const replayedCallback = await handleRequest(
+      request(`/api/auth/google/callback?state=${start.state}&code=auth-code`),
+      oauthEnv,
+      { repository, jobs }
+    );
+    expect(replayedCallback.status).toBe(400);
+    expect((await body(replayedCallback)).error.code).toBe("invalid_oauth_state");
+  });
+
+  it("requires a valid oauth session for me and extension-token", async () => {
+    const sessionKv = createSessionKv({
+      "session:ses_valid": JSON.stringify({
+        user_id: "usr_oauth",
+        provider: "google",
+        handle: "oauth-user",
+        display_name: "OAuth User"
+      })
+    });
+    const oauthEnv: Env = {
+      ...env,
+      AUTH_MODE: "oauth",
+      SESSION_KV: sessionKv
+    };
+
+    const missingMe = await handleRequest(request("/api/me"), oauthEnv, { repository, jobs });
+    expect(missingMe.status).toBe(401);
+    expect((await body(missingMe)).error.code).toBe("authentication_required");
+
+    const validMe = await handleRequest(
+      request("/api/me", {
+        headers: {
+          Cookie: "annotated_session=ses_valid",
+          Origin: "http://localhost:5173"
+        }
+      }),
+      oauthEnv,
+      { repository, jobs }
+    );
+    expect(validMe.status).toBe(200);
+    expect(validMe.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:5173");
+    expect(validMe.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    expect((await body(validMe)).user).toMatchObject({
+      id: "usr_oauth",
+      handle: "oauth-user",
+      display_name: "OAuth User"
+    });
+
+    const deniedToken = await handleRequest(
+      request("/api/auth/extension-token", {
+        method: "POST"
+      }),
+      oauthEnv,
+      { repository, jobs }
+    );
+    expect(deniedToken.status).toBe(401);
+
+    const token = await handleRequest(
+      request("/api/auth/extension-token", {
+        method: "POST",
+        headers: {
+          Cookie: "annotated_session=ses_valid"
+        }
+      }),
+      oauthEnv,
+      { repository, jobs }
+    );
+    expect(token.status).toBe(200);
+    expect((await body(token)).token_type).toBe("Bearer");
+  });
+
+  it("deletes the session on logout when session KV is available", async () => {
+    const sessionKv = createSessionKv({
+      "session:ses_valid": JSON.stringify({
+        user_id: "usr_oauth",
+        provider: "google"
+      })
+    });
+
+    const response = await handleRequest(
+      request("/api/auth/logout", {
+        method: "POST",
+        headers: {
+          Cookie: "annotated_session=ses_valid"
+        }
+      }),
+      {
+        ...env,
+        AUTH_MODE: "oauth",
+        SESSION_KV: sessionKv
+      },
+      { repository, jobs }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Set-Cookie")).toContain("Max-Age=0");
+    expect(sessionKv.store.has("session:ses_valid")).toBe(false);
+  });
+
+  it("uses production-safe cookies and rejects open redirect return_to values", async () => {
+    const productionEnv: Env = {
+      ...env,
+      APP_ORIGIN: "https://annotated-canvas.pages.dev",
+      SESSION_KV: createSessionKv()
+    };
+
+    const start = await body(
+      await handleRequest(
+        request("/api/auth/google/start?return_to=https://attacker.example/after-auth"),
+        productionEnv,
+        { repository, jobs }
+      )
+    );
+    expect(start.authorization_url).toContain("return_to=https%3A%2F%2Fannotated-canvas.pages.dev");
+
+    const callback = await handleRequest(
+      request(`/api/auth/google/callback?state=${start.state}&code=demo&return_to=https://attacker.example/after-auth`),
+      productionEnv,
+      { repository, jobs }
+    );
+
+    expect(callback.status).toBe(302);
+    expect(callback.headers.get("Location")).toBe("https://annotated-canvas.pages.dev");
+    expect(callback.headers.get("Set-Cookie")).toContain("SameSite=None; Secure");
   });
 
   it("serves p50 user profile, annotations, and follow contract routes", async () => {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -18,6 +18,26 @@ interface Services {
   jobs: JobQueue;
 }
 
+type AuthProvider = "x" | "google";
+
+interface OAuthState {
+  provider: AuthProvider;
+  return_to: string;
+}
+
+interface AuthSession {
+  user_id: string;
+  provider?: AuthProvider;
+  handle?: string;
+  display_name?: string;
+}
+
+const DEMO_USER = {
+  id: "usr_demo",
+  handle: "mira",
+  display_name: "Mira Chen"
+};
+
 const defaultRepositories = new Map<string, InMemoryRepository>();
 
 function getDefaultRepository(appOrigin: string): InMemoryRepository {
@@ -37,35 +57,61 @@ export function makeServices(env: Env): Services {
   };
 }
 
-function corsHeaders(env: Env): HeadersInit {
-  return {
-    "Access-Control-Allow-Origin": "*",
+function isAllowedCorsOrigin(origin: string, env: Env): boolean {
+  const appOrigin = normalizeAppOrigin(env.APP_ORIGIN);
+  return (
+    origin === appOrigin ||
+    origin === "http://localhost:5173" ||
+    origin === "http://127.0.0.1:5173" ||
+    origin.startsWith("chrome-extension://")
+  );
+}
+
+function corsHeaders(env: Env, request?: Request): HeadersInit {
+  const origin = request?.headers.get("Origin");
+  const accessControlOrigin = origin && isAllowedCorsOrigin(origin, env) ? origin : "*";
+  const headers: Record<string, string> = {
+    "Access-Control-Allow-Origin": accessControlOrigin,
     "Access-Control-Allow-Headers": "Content-Type, Idempotency-Key, Authorization",
     "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
     "Access-Control-Max-Age": "86400",
     "Vary": "Origin"
   };
+
+  if (accessControlOrigin !== "*") {
+    headers["Access-Control-Allow-Credentials"] = "true";
+  }
+
+  return headers;
 }
 
-function json(env: Env, body: unknown, init: ResponseInit = {}): Response {
+function json(env: Env, body: unknown, init: ResponseInit = {}, request?: Request): Response {
   return new Response(JSON.stringify(body, null, 2), {
     ...init,
     headers: {
       "Content-Type": "application/json; charset=utf-8",
-      ...corsHeaders(env),
+      ...corsHeaders(env, request),
       ...init.headers
     }
   });
 }
 
-function error(env: Env, status: number, code: string, message: string, details: Record<string, unknown> = {}): Response {
+function error(
+  env: Env,
+  status: number,
+  code: string,
+  message: string,
+  details: Record<string, unknown> = {},
+  request?: Request
+): Response {
   return json(
     env,
     {
       error: { code, message, details },
       request_id: createRequestId()
     },
-    { status }
+    { status },
+    request
   );
 }
 
@@ -91,11 +137,162 @@ function queueJob(type: QueueJob["type"], ids: Partial<Pick<QueueJob, "annotatio
   };
 }
 
+function authMode(env: Env): "demo" | "oauth" {
+  return env.AUTH_MODE ?? "demo";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getProviderCredentials(env: Env, provider: AuthProvider) {
+  return provider === "google"
+    ? {
+        clientId: env.GOOGLE_CLIENT_ID,
+        clientSecret: env.GOOGLE_CLIENT_SECRET,
+        clientIdName: "GOOGLE_CLIENT_ID",
+        clientSecretName: "GOOGLE_CLIENT_SECRET"
+      }
+    : {
+        clientId: env.X_CLIENT_ID,
+        clientSecret: env.X_CLIENT_SECRET,
+        clientIdName: "X_CLIENT_ID",
+        clientSecretName: "X_CLIENT_SECRET"
+      };
+}
+
+function missingOAuthConfig(env: Env, provider: AuthProvider): string[] {
+  const credentials = getProviderCredentials(env, provider);
+  return [
+    !credentials.clientId ? credentials.clientIdName : null,
+    !credentials.clientSecret ? credentials.clientSecretName : null,
+    !env.SESSION_KV ? "SESSION_KV" : null
+  ].filter((item): item is string => Boolean(item));
+}
+
+function oauthConfigError(env: Env, request: Request, provider: AuthProvider, missing: string[]): Response {
+  return error(env, 503, "auth_not_configured", "OAuth is not configured for this provider.", {
+    provider,
+    missing
+  }, request);
+}
+
+function parseCookie(request: Request, name: string): string | null {
+  const cookieHeader = request.headers.get("Cookie");
+  if (!cookieHeader) return null;
+
+  for (const cookie of cookieHeader.split(";")) {
+    const [rawName, ...rawValue] = cookie.trim().split("=");
+    if (rawName !== name) continue;
+    const value = rawValue.join("=");
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function parseOAuthState(value: string): OAuthState | null {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (
+      isRecord(parsed) &&
+      (parsed.provider === "x" || parsed.provider === "google") &&
+      typeof parsed.return_to === "string"
+    ) {
+      return {
+        provider: parsed.provider,
+        return_to: parsed.return_to
+      };
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function parseAuthSession(value: string): AuthSession | null {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!isRecord(parsed) || typeof parsed.user_id !== "string" || parsed.user_id.length === 0) {
+      return null;
+    }
+
+    return {
+      user_id: parsed.user_id,
+      provider: parsed.provider === "x" || parsed.provider === "google" ? parsed.provider : undefined,
+      handle: typeof parsed.handle === "string" ? parsed.handle : undefined,
+      display_name: typeof parsed.display_name === "string" ? parsed.display_name : undefined
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function requireOAuthSession(request: Request, env: Env): Promise<AuthSession | Response> {
+  if (!env.SESSION_KV) {
+    return error(env, 503, "auth_not_configured", "OAuth sessions require SESSION_KV.", {}, request);
+  }
+
+  const sessionId = parseCookie(request, "annotated_session");
+  if (!sessionId) {
+    return error(env, 401, "authentication_required", "A valid session is required.", {}, request);
+  }
+
+  const sessionPayload = await env.SESSION_KV.get(`session:${sessionId}`);
+  if (!sessionPayload) {
+    return error(env, 401, "authentication_required", "A valid session is required.", {}, request);
+  }
+
+  const session = parseAuthSession(sessionPayload);
+  if (!session) {
+    return error(env, 401, "authentication_required", "A valid session is required.", {}, request);
+  }
+
+  return session;
+}
+
+function resolveReturnTo(env: Env, rawReturnTo: string | null): string {
+  const appOrigin = normalizeAppOrigin(env.APP_ORIGIN);
+  if (!rawReturnTo) return appOrigin;
+
+  try {
+    const candidate = new URL(rawReturnTo, appOrigin);
+    if (candidate.origin === appOrigin) return candidate.toString();
+  } catch {
+    return appOrigin;
+  }
+
+  return appOrigin;
+}
+
+function sessionCookie(name: string, value: string, env: Env, maxAgeSeconds: number): string {
+  const encodedValue = encodeURIComponent(value);
+  const sameSite = normalizeAppOrigin(env.APP_ORIGIN).startsWith("https://") ? "SameSite=None; Secure" : "SameSite=Lax";
+  return `${name}=${encodedValue}; Path=/; HttpOnly; ${sameSite}; Max-Age=${maxAgeSeconds}`;
+}
+
+function expiredSessionCookie(env: Env): string {
+  return `${sessionCookie("annotated_session", "", env, 0)}; Expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+}
+
+function userFromSession(session: AuthSession) {
+  return {
+    id: session.user_id,
+    handle: session.handle ?? DEMO_USER.handle,
+    display_name: session.display_name ?? DEMO_USER.display_name
+  };
+}
+
 export async function handleRequest(request: Request, env: Env, services = makeServices(env)): Promise<Response> {
   const url = new URL(request.url);
 
   if (request.method === "OPTIONS") {
-    return new Response(null, { headers: corsHeaders(env) });
+    return new Response(null, { headers: corsHeaders(env, request) });
   }
 
   if (url.pathname === "/api/health" && request.method === "GET") {
@@ -107,17 +304,26 @@ export async function handleRequest(request: Request, env: Env, services = makeS
   }
 
   if (url.pathname === "/api/me" && request.method === "GET") {
+    if (authMode(env) === "oauth") {
+      const session = await requireOAuthSession(request, env);
+      if (session instanceof Response) return session;
+
+      return json(env, {
+        user: userFromSession(session),
+        auth: {
+          providers: ["x", "google"],
+          extension_token_supported: true
+        }
+      }, {}, request);
+    }
+
     return json(env, {
-      user: {
-        id: "usr_demo",
-        handle: "mira",
-        display_name: "Mira Chen"
-      },
+      user: DEMO_USER,
       auth: {
         providers: ["x", "google"],
         extension_token_supported: true
       }
-    });
+    }, {}, request);
   }
 
   const authStartMatch = url.pathname.match(/^\/api\/auth\/([^/]+)\/start$/);
@@ -127,9 +333,15 @@ export async function handleRequest(request: Request, env: Env, services = makeS
       return error(env, 400, "unsupported_auth_provider", "Auth provider must be x or google.");
     }
 
-    const returnTo = url.searchParams.get("return_to") ?? "/";
+    const returnTo = resolveReturnTo(env, url.searchParams.get("return_to"));
     const state = `state_${crypto.randomUUID()}`;
-    const mode = env.AUTH_MODE ?? "demo";
+    const mode = authMode(env);
+    const credentials = getProviderCredentials(env, provider.data);
+    const missing = mode === "oauth" ? missingOAuthConfig(env, provider.data) : [];
+    if (missing.length > 0) {
+      return oauthConfigError(env, request, provider.data, missing);
+    }
+
     const callbackUrl = new URL(`/api/auth/${provider.data}/callback`, url.origin);
     callbackUrl.searchParams.set("state", state);
     callbackUrl.searchParams.set("return_to", returnTo);
@@ -143,10 +355,9 @@ export async function handleRequest(request: Request, env: Env, services = makeS
       );
     }
 
-    const clientId = provider.data === "google" ? env.GOOGLE_CLIENT_ID : env.X_CLIENT_ID;
     const authorizationUrl =
-      mode === "oauth" && clientId
-        ? buildProviderAuthorizationUrl(provider.data, clientId, callbackUrl.toString(), state)
+      mode === "oauth" && credentials.clientId
+        ? buildProviderAuthorizationUrl(provider.data, credentials.clientId, callbackUrl.toString(), state)
         : callbackUrl.toString();
 
     return json(env, {
@@ -165,16 +376,48 @@ export async function handleRequest(request: Request, env: Env, services = makeS
     }
 
     const state = url.searchParams.get("state");
-    const returnTo = url.searchParams.get("return_to") ?? "/";
+    const returnTo = resolveReturnTo(env, url.searchParams.get("return_to"));
     if (!state) {
       return error(env, 400, "oauth_state_required", "OAuth callback requires state.");
+    }
+
+    if (authMode(env) === "oauth") {
+      const code = url.searchParams.get("code");
+      if (!code) {
+        return error(env, 400, "oauth_code_required", "OAuth callback requires code.");
+      }
+
+      if (!env.SESSION_KV) {
+        return error(env, 503, "auth_not_configured", "OAuth state validation requires SESSION_KV.");
+      }
+
+      const stateKey = `oauth_state:${state}`;
+      const storedStatePayload = await env.SESSION_KV.get(stateKey);
+      if (!storedStatePayload) {
+        return error(env, 400, "invalid_oauth_state", "OAuth state is invalid or has already been used.");
+      }
+
+      await env.SESSION_KV.delete(stateKey);
+      const storedState = parseOAuthState(storedStatePayload);
+      if (!storedState || storedState.provider !== provider.data) {
+        return error(env, 400, "invalid_oauth_state", "OAuth state is invalid or has already been used.");
+      }
+
+      return error(env, 501, "not_implemented", "OAuth token exchange is not implemented.", {
+        provider: provider.data
+      });
     }
 
     const sessionId = `ses_${crypto.randomUUID()}`;
     if (env.SESSION_KV) {
       await env.SESSION_KV.put(
         `session:${sessionId}`,
-        JSON.stringify({ user_id: "usr_demo", provider: provider.data }),
+        JSON.stringify({
+          user_id: DEMO_USER.id,
+          provider: provider.data,
+          handle: DEMO_USER.handle,
+          display_name: DEMO_USER.display_name
+        }),
         { expirationTtl: 60 * 60 * 24 * 14 }
       );
     }
@@ -183,13 +426,18 @@ export async function handleRequest(request: Request, env: Env, services = makeS
       status: 302,
       headers: {
         Location: returnTo,
-        "Set-Cookie": `annotated_session=${sessionId}; Path=/; HttpOnly; SameSite=Lax; Max-Age=1209600`,
-        ...corsHeaders(env)
+        "Set-Cookie": sessionCookie("annotated_session", sessionId, env, 1209600),
+        ...corsHeaders(env, request)
       }
     });
   }
 
   if (url.pathname === "/api/auth/extension-token" && request.method === "POST") {
+    if (authMode(env) === "oauth") {
+      const session = await requireOAuthSession(request, env);
+      if (session instanceof Response) return session;
+    }
+
     return json(env, {
       token: `ext_${crypto.randomUUID()}`,
       expires_in: 3600,
@@ -198,14 +446,20 @@ export async function handleRequest(request: Request, env: Env, services = makeS
   }
 
   if (url.pathname === "/api/auth/logout" && request.method === "POST") {
+    const sessionId = parseCookie(request, "annotated_session");
+    if (env.SESSION_KV && sessionId) {
+      await env.SESSION_KV.delete(`session:${sessionId}`);
+    }
+
     return json(
       env,
       { ok: true },
       {
         headers: {
-          "Set-Cookie": "annotated_session=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0"
+          "Set-Cookie": expiredSessionCookie(env)
         }
-      }
+      },
+      request
     );
   }
 

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -23,7 +23,9 @@ export interface Env {
   SERVICE_MODE?: string;
   AUTH_MODE?: "demo" | "oauth";
   GOOGLE_CLIENT_ID?: string;
+  GOOGLE_CLIENT_SECRET?: string;
   X_CLIENT_ID?: string;
+  X_CLIENT_SECRET?: string;
   DB?: D1Database;
   SESSION_KV?: KVNamespace;
   MEDIA_BUCKET?: R2Bucket;

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,9 +1,55 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
 
 describe("Annotated web shell", () => {
+  function requestUrl(input: RequestInfo | URL) {
+    return typeof input === "string" ? input : "url" in input ? input.url : input.toString();
+  }
+
+  function jsonResponse(body: unknown, status = 200) {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: {
+        "Content-Type": "application/json"
+      }
+    });
+  }
+
+  async function defaultFetch(input: RequestInfo | URL) {
+    const url = requestUrl(input);
+
+    if (url.includes("/api/me")) {
+      return jsonResponse({
+        user: null,
+        auth: {
+          providers: ["x", "google"],
+          extension_token_supported: true
+        }
+      });
+    }
+
+    return jsonResponse(
+      {
+        error: {
+          code: "unexpected_test_request",
+          message: `Unexpected test request: ${url}`
+        }
+      },
+      404
+    );
+  }
+
+  beforeEach(() => {
+    window.history.pushState(null, "", "/");
+    vi.stubGlobal("fetch", vi.fn(defaultFetch));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   function renderAt(pathname: string) {
     window.history.pushState(null, "", pathname);
     return render(<App />);
@@ -53,6 +99,89 @@ describe("Annotated web shell", () => {
     expect(screen.getByRole("heading", { name: /save the exact moment/i })).toBeInTheDocument();
     expect(screen.getByText("Sign in with Google")).toBeInTheDocument();
     expect(screen.getByText("View public feed")).toBeInTheDocument();
+  });
+
+  it("checks signed-out session state with credentials on load", async () => {
+    renderAt("/");
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(expect.stringContaining("/api/me"), {
+        credentials: "include"
+      });
+    });
+    expect(screen.getByText("Signed out")).toBeInTheDocument();
+  });
+
+  it("opens provider choice from header and renders missing-provider errors inline", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+
+      if (url.includes("/api/me")) {
+        return jsonResponse({ user: null });
+      }
+
+      if (url.includes("/api/auth/google/start")) {
+        return jsonResponse(
+          {
+            error: {
+              code: "auth_provider_not_configured",
+              message: "Google sign-in is not configured."
+            }
+          },
+          503
+        );
+      }
+
+      return defaultFetch(input);
+    });
+
+    renderAt("/");
+
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    expect(screen.getByRole("heading", { name: /save the exact moment/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /sign in with google/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("/api/auth/google/start?"), {
+        method: "GET"
+      });
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent(/google sign-in is not configured/i);
+  });
+
+  it("starts X auth through fetch and follows the returned authorization URL", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.mocked(fetch);
+    let authorizationUrl = "";
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+
+      if (url.includes("/api/me")) {
+        return jsonResponse({ user: null });
+      }
+
+      if (url.includes("/api/auth/x/start")) {
+        return jsonResponse({ authorization_url: authorizationUrl });
+      }
+
+      return defaultFetch(input);
+    });
+
+    renderAt("/home");
+    authorizationUrl = new URL("/oauth/x", window.location.href).toString();
+
+    await user.click(screen.getByRole("button", { name: /sign in with x/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("/api/auth/x/start?"), {
+        method: "GET"
+      });
+      expect(window.location.href).toBe(authorizationUrl);
+    });
   });
 
   it("renders the bounty URL capture composer on the feed", () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,6 +4,8 @@ import { Bell, Check, Flag, LogIn, Send, UserPlus } from "lucide-react";
 import { type FormEvent, useEffect, useMemo, useState } from "react";
 import {
   API_BASE,
+  ApiRequestError,
+  loadCurrentViewer,
   loadAnnotation,
   loadComments,
   loadFeed,
@@ -12,11 +14,14 @@ import {
   publishWebAnnotation,
   sendEngagement,
   setFollow,
+  startAuth,
   submitClaim,
-  submitComment
+  submitComment,
+  type AuthProvider
 } from "./api";
 
 type View = "home" | "feed" | "profile" | "annotation" | "empty" | "removed" | "signup";
+type ViewerState = "loading" | "signed-in" | "signed-out";
 
 function clipSource(clip: AnnotationResource["clip"]) {
   return "source" in clip ? clip.source : undefined;
@@ -44,6 +49,12 @@ function parseSeconds(value: string): number {
 
 export function App() {
   const [view, setView] = useState<View>(() => viewFromPath(window.location.pathname));
+  const [viewerState, setViewerState] = useState<ViewerState>("loading");
+  const [viewer, setViewer] = useState<Pick<UserResource, "id" | "handle" | "display_name" | "avatar_url"> | null>(
+    null
+  );
+  const [authPending, setAuthPending] = useState<AuthProvider | null>(null);
+  const [authError, setAuthError] = useState<string | null>(null);
   const [claimTarget, setClaimTarget] = useState<AnnotationResource | null>(null);
   const [claimReason, setClaimReason] = useState("Please review this annotation and its source usage.");
   const [claimStatus, setClaimStatus] = useState<string | null>(null);
@@ -85,6 +96,26 @@ export function App() {
   const featuredSource = clipSource(featured.clip);
 
   useEffect(() => {
+    let cancelled = false;
+
+    void loadCurrentViewer()
+      .then((session) => {
+        if (cancelled) return;
+        setViewer(session.user);
+        setViewerState(session.user ? "signed-in" : "signed-out");
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setViewer(null);
+        setViewerState("signed-out");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
     if (view === "feed") {
       void loadFeed().then(setFeedItems);
     }
@@ -104,10 +135,44 @@ export function App() {
     }
   }, [view]);
 
+  function showAuthChoice() {
+    setAuthError(null);
+    window.history.pushState(null, "", "/signup");
+    setView("signup");
+  }
+
   function navigate(nextView: "feed" | "profile" | "annotation") {
     const path = nextView === "feed" ? "/" : nextView === "profile" ? "/u/mira" : "/a/ann_video_minimalism";
     window.history.pushState(null, "", path);
     setView(nextView);
+  }
+
+  function providerLabel(provider: AuthProvider) {
+    return provider === "google" ? "Google" : "X";
+  }
+
+  function authErrorMessage(error: unknown, provider: AuthProvider) {
+    if (error instanceof ApiRequestError) {
+      const configuredError =
+        error.code?.includes("not_configured") || error.message.toLowerCase().includes("configured");
+      return configuredError ? `${providerLabel(provider)} sign-in is not configured yet.` : error.message;
+    }
+
+    return `Could not start ${providerLabel(provider)} sign-in.`;
+  }
+
+  async function handleAuthStart(provider: AuthProvider) {
+    setAuthError(null);
+    setAuthPending(provider);
+
+    try {
+      const authorizationUrl = await startAuth(provider, window.location.href);
+      window.location.href = authorizationUrl;
+    } catch (error) {
+      setAuthError(authErrorMessage(error, provider));
+    } finally {
+      setAuthPending(null);
+    }
   }
 
   function replaceAnnotation(next: AnnotationResource) {
@@ -216,10 +281,21 @@ export function App() {
         active={view}
         onNavigate={navigate}
         actions={
-          <Button tone="secondary">
-            <LogIn size={16} aria-hidden="true" />
-            Sign in
-          </Button>
+          <div className="header-auth">
+            <span className="header-auth__state" aria-live="polite">
+              {viewerState === "loading"
+                ? "Checking session"
+                : viewer
+                  ? `Signed in as @${viewer.handle}`
+                  : "Signed out"}
+            </span>
+            {viewer ? null : (
+              <Button tone="secondary" type="button" onClick={showAuthChoice}>
+                <LogIn size={16} aria-hidden="true" />
+                Sign in
+              </Button>
+            )}
+          </div>
         }
       />
 
@@ -255,19 +331,31 @@ export function App() {
               to the original page.
             </p>
             <div className="marketing-actions">
-              <a
+              <button
+                type="button"
                 className="marketing-button marketing-button--primary"
-                href={`${API_BASE}/api/auth/google/start?return_to=/`}
+                onClick={() => void handleAuthStart("google")}
+                disabled={authPending !== null}
               >
-                Sign in with Google
-              </a>
-              <a className="marketing-button" href={`${API_BASE}/api/auth/x/start?return_to=/`}>
-                Sign in with X
-              </a>
+                {authPending === "google" ? "Starting Google..." : "Sign in with Google"}
+              </button>
+              <button
+                type="button"
+                className="marketing-button"
+                onClick={() => void handleAuthStart("x")}
+                disabled={authPending !== null}
+              >
+                {authPending === "x" ? "Starting X..." : "Sign in with X"}
+              </button>
               <button type="button" onClick={() => navigate("feed")}>
                 View public feed
               </button>
             </div>
+            {authError ? (
+              <p className="auth-error" role="alert">
+                {authError}
+              </p>
+            ) : null}
             <div className="feed-list marketing-preview">
               {feedItems.slice(0, 2).map((annotation) => (
                 <AnnotationCard

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -13,10 +13,79 @@ export const API_BASE =
   import.meta.env.VITE_API_BASE_URL ?? (import.meta.env.DEV ? "http://localhost:8787" : "");
 const shouldFetch = import.meta.env.MODE !== "test";
 
+export type AuthProvider = "google" | "x";
+export type ViewerSession = {
+  user: Pick<UserResource, "id" | "handle" | "display_name" | "avatar_url"> | null;
+  auth?: {
+    providers?: AuthProvider[];
+    extension_token_supported?: boolean;
+  };
+};
+
+type ErrorEnvelope = {
+  error?: {
+    code?: string;
+    message?: string;
+  };
+};
+
+export class ApiRequestError extends Error {
+  readonly status: number;
+  readonly code?: string;
+
+  constructor(status: number, message: string, code?: string) {
+    super(message);
+    this.name = "ApiRequestError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
 async function getJson<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE}${path}`);
   if (!response.ok) throw new Error(`GET ${path} failed`);
   return response.json() as Promise<T>;
+}
+
+async function requestError(response: Response, fallback: string): Promise<ApiRequestError> {
+  try {
+    const payload = (await response.json()) as ErrorEnvelope;
+    return new ApiRequestError(response.status, payload.error?.message ?? fallback, payload.error?.code);
+  } catch {
+    return new ApiRequestError(response.status, fallback);
+  }
+}
+
+export async function loadCurrentViewer(): Promise<ViewerSession> {
+  const response = await fetch(`${API_BASE}/api/me`, {
+    credentials: "include"
+  });
+
+  if (response.status === 401 || response.status === 403) return { user: null };
+  if (!response.ok) throw await requestError(response, "Could not check sign-in status.");
+
+  const payload = (await response.json()) as ViewerSession;
+  return {
+    user: payload.user ?? null,
+    auth: payload.auth
+  };
+}
+
+export async function startAuth(provider: AuthProvider, returnTo: string): Promise<string> {
+  const search = new URLSearchParams({ return_to: returnTo });
+  const response = await fetch(`${API_BASE}/api/auth/${provider}/start?${search.toString()}`, {
+    method: "GET"
+  });
+
+  if (!response.ok) {
+    throw await requestError(response, `Could not start ${provider === "google" ? "Google" : "X"} sign-in.`);
+  }
+
+  const payload = (await response.json()) as { authorization_url?: string };
+  if (!payload.authorization_url) {
+    throw new ApiRequestError(response.status, "Sign-in is not configured for this provider yet.", "auth_not_configured");
+  }
+  return payload.authorization_url;
 }
 
 export async function loadFeed(): Promise<AnnotationResource[]> {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -70,6 +70,19 @@
   gap: 22px;
 }
 
+.header-auth {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.header-auth__state {
+  color: var(--ac-muted);
+  font-size: 13px;
+  white-space: nowrap;
+}
+
 .composer,
 .comments-panel {
   border: 1px solid var(--ac-border);
@@ -217,10 +230,21 @@
   cursor: pointer;
 }
 
+.marketing-actions button:disabled {
+  cursor: wait;
+  opacity: 0.72;
+}
+
 .marketing-actions .marketing-button--primary {
   background: var(--ac-primary);
   color: #fff;
   border-color: var(--ac-primary);
+}
+
+.auth-error {
+  margin: -10px 0 0;
+  color: var(--ac-danger);
+  font-size: 13px;
 }
 
 .marketing-preview {
@@ -526,6 +550,10 @@
 
   .rail--right {
     grid-template-columns: 1fr;
+  }
+
+  .header-auth {
+    justify-content: flex-start;
   }
 
   .permalink-view > h2 {

--- a/docs/chrome-extension-local-smoke.md
+++ b/docs/chrome-extension-local-smoke.md
@@ -59,13 +59,38 @@ curl http://localhost:8787/api/health
 
 If testing a deployed Worker, open the side panel Settings tab, replace the API URL with the deployed Worker origin, and save. This should not require a source edit or rebuild.
 
+## Production Worker Setup
+
+Use this API base for the #23/#30 production extension proof:
+
+```text
+https://annotated-canvas-api.jaybhagat841.workers.dev
+```
+
+Production health baseline observed on May 1, 2026:
+
+```sh
+curl https://annotated-canvas-api.jaybhagat841.workers.dev/api/health
+```
+
+Expected response shape:
+
+```json
+{
+  "ok": true,
+  "service": "annotated-canvas-api",
+  "mode": "production"
+}
+```
+
 ## Smoke Checklist
 
 - [x] `npm run build:extension` exits successfully and leaves `dist/extension/manifest.json`, `sidepanel.html`, `sidepanel.js`, `service-worker.js`, `content-script.js`, and `assets/sidepanel.css`.
 - [x] Chrome loads `dist/extension` without manifest or permission errors.
 - [x] Extension action opens the Chrome side panel.
 - [x] Settings tab shows `http://localhost:8787` by default.
-- [x] Settings tab saves the API URL in `chrome.storage.local`; production Worker URL switching remains pending until deployment URL exists.
+- [x] Settings tab saves the API URL in `chrome.storage.local`.
+- [ ] Settings tab saves `https://annotated-canvas-api.jaybhagat841.workers.dev`, survives side-panel close/reopen, and publishes to the production Worker without source edits.
 - [ ] On a text page, select text, right-click, choose `Annotate selected text`, and confirm the side panel displays the selected text path.
 - [x] On a normal page, confirm the side panel reads the active tab URL/title through the content-script/tab fallback path.
 - [ ] On a media page, confirm the side panel seeds a time range from the current media time when available.
@@ -87,19 +112,115 @@ If testing a deployed Worker, open the side panel Settings tab, replace the API 
 - Publish: side panel published a 47-second time range with commentary `Local extension smoke test for bounty criteria: capture from active tab to local API.`
 - API feed proof: `GET /api/feed` returned `ann_e496763a-fb93-457b-a3f7-a6659d4f3e9d` with source URL `http://127.0.0.1:5173/`, domain `127.0.0.1`, title `Annotated Canvas`, and the smoke-test commentary.
 
+## Sequenced Production p50/p95 Smoke Plan
+
+Run this sequence after rebuilding and reloading `dist/extension`. Keep Chrome DevTools Network open for the side panel, clear the log before each publish/rejection case, and preserve the request payloads or export a HAR where practical.
+
+### Setup And API-Base Switch
+
+1. Build the artifact with `npm run build:extension`.
+2. Record `ls -1 dist/extension` showing `manifest.json`, `sidepanel.html`, `sidepanel.js`, `service-worker.js`, `content-script.js`, and `assets/sidepanel.css`.
+3. Open `chrome://extensions`, reload the `Annotated Canvas` unpacked extension, and record the extension card with Developer Mode enabled.
+4. Open the side panel, go to Settings, replace `http://localhost:8787` with `https://annotated-canvas-api.jaybhagat841.workers.dev`, and click `Save settings`.
+5. Close and reopen the side panel. The `API URL` field should still show the production Worker URL.
+6. Capture `curl -i https://annotated-canvas-api.jaybhagat841.workers.dev/api/health` returning `200` with `"mode": "production"`.
+
+Evidence to retain: build output, extension-card screenshot or recording, Settings screenshot before and after save, reopened Settings screenshot, the health-check response, and confirmation that no app or API source files were edited for the API-base switch.
+
+### p50 Happy Path
+
+1. Open a normal source page in Chrome.
+2. Open the extension side panel and verify the displayed source title/domain matches the active tab.
+3. Leave `Time range` selected, enter a range of 90 seconds or less, add a unique text note, and click `Publish annotation`.
+4. Verify the side panel reaches `Published`.
+5. Fetch the returned annotation or `GET https://annotated-canvas-api.jaybhagat841.workers.dev/api/feed` and confirm the new id appears.
+
+Evidence to retain: side-panel source screenshot, Network `POST /api/annotations` request to the production Worker, request JSON with `client_context.surface: "extension"`, response annotation id, feed/permalink/API proof for that id, and the exact commentary string used for correlation.
+
+### p95 Selected-Text Context Menu
+
+1. Open a normal HTTPS text page that allows selection.
+2. Select a short exact quote. Prefer a sentence stable enough to compare byte-for-byte in the payload.
+3. Right-click the selection and choose `Annotate selected text`.
+4. Verify the side panel opens in `Selected text` mode and the quote preview matches the selected text exactly.
+5. Add a unique note and publish to the production Worker.
+
+Evidence to retain: screenshot or recording of the selected browser text, the context menu item `Annotate selected text`, the side-panel quote preview, and the production `POST /api/annotations` payload showing:
+
+```json
+{
+  "clip": {
+    "kind": "text",
+    "text": {
+      "quote": "the exact selected quote"
+    }
+  },
+  "client_context": {
+    "surface": "extension",
+    "capture_method": "selection"
+  }
+}
+```
+
+Also retain the response annotation id and a follow-up API/permalink/feed response proving the stored annotation still contains the same quote and source URL.
+
+### p95 Real Media Current-Time Capture
+
+1. Open a page with a real top-level `<video>` or `<audio>` element. Avoid iframe-only players for this proof unless the extension explicitly supports reading them.
+2. Play or seek the media to a known current time, such as `00:01:12`.
+3. Before opening the side panel, capture DevTools Console output for:
+
+   ```js
+   document.querySelector("video,audio")?.currentTime
+   document.querySelector("video,audio")?.tagName
+   ```
+
+4. Open or reload the side panel. The `Start` field should seed from `Math.floor(currentTime)`, and `End` should seed to `Start + 47`.
+5. Publish a 90-second-or-less range to the production Worker.
+
+Evidence to retain: media page URL/title, media control or console proof of `currentTime`, side-panel `Start` and `End` fields, production `POST /api/annotations` payload showing `clip.kind` as `video` or `audio`, and exact `media.start_seconds`, `media.end_seconds`, and `media.duration_seconds`. Confirm the stored annotation through API/feed/permalink evidence.
+
+### p95 Over-90-Second Rejection
+
+1. Keep the production Worker URL saved in Settings.
+2. On the media capture screen, clear the Network log.
+3. Enter a range longer than 90 seconds, for example `Start` = `00:00:00` and `End` = `00:01:31`.
+4. Click `Publish annotation`.
+5. Confirm the side panel shows `Clip length must be 90 seconds or less.`
+6. Confirm no new `POST /api/annotations` request was sent after the click.
+
+Evidence to retain: side-panel fields, the exact error text, a Network panel screenshot or HAR showing no production `POST /api/annotations` for the rejected click, and a note that API/contract validation still rejects over-90 payloads if sent directly.
+
+### p95 Audio/R2 Limitation
+
+1. Keep the production Worker URL saved in Settings.
+2. Click `Record voice note`, handle Chrome's microphone prompt, stop recording, and record whether the side panel shows `Voice note ready` or `Microphone permission was blocked.`
+3. If a voice note is ready, publish with a short text or media capture.
+4. Capture the production `POST /api/uploads/audio-commentary` response.
+5. Independently verify the production upload fallback with:
+
+   ```sh
+   printf 'audio-smoke' | curl -sS -X POST \
+     "https://annotated-canvas-api.jaybhagat841.workers.dev/api/uploads/audio-commentary" \
+     -H "Content-Type: audio/webm" \
+     --data-binary @-
+   ```
+
+Evidence to retain: microphone prompt or blocker screenshot, `Voice note ready` screenshot if recording succeeds, upload response JSON showing `upload.storage: "r2"` and `upload.status: "intent-created"` rather than `"stored"`, and a submission note that production omits `MEDIA_BUCKET` until #26 enables R2 or another durable audio storage path.
+
 ## Evidence To Capture
 
 - Terminal output from `npm run build:extension`.
 - File listing for `dist/extension`.
 - Screenshot or recording of the loaded extension card at `chrome://extensions`.
 - Screenshot or recording of the side panel opened on a real page.
-- Screenshot or recording of selected text capture.
-- Screenshot or recording of media time range capture.
-- Screenshot or recording of the over-90-second client-side validation.
+- Screenshot or recording of selected text capture, including the context menu item and exact quote.
+- Screenshot or recording of media time range capture, including real media `currentTime` and seeded `Start`/`End`.
+- Screenshot or recording of the over-90-second client-side validation and proof that no network publish occurred.
 - Network/API evidence for successful publish, including annotation id.
 - Feed, permalink, or API response proving the published annotation is visible.
-- Settings proof showing localhost and production API base switching.
-- Audio commentary proof, or a precise microphone/upload/R2 blocker.
+- Settings proof showing localhost and production API base switching to `https://annotated-canvas-api.jaybhagat841.workers.dev`.
+- Audio commentary proof, or a precise microphone/upload/R2 blocker with `status: "intent-created"`.
 
 ## Bounty Criteria Mapping
 
@@ -132,5 +253,5 @@ Capture these in `docs/issue-learning-loop.md` or the issue thread after browser
 - Selected-text context menu capture still needs a browser proof pass on a normal content page.
 - Media current-time seeding still needs a proof pass on a real video/audio page.
 - Over-90-second client-side validation still needs browser proof, even though unit coverage exercises the publish path.
-- Audio commentary needs microphone permission and upload proof against local or deployed R2-backed storage.
-- Production API URL switching needs the deployed Cloudflare Worker URL.
+- Audio commentary needs microphone permission and upload proof; production currently returns the R2-disabled `intent-created` fallback until #26 enables durable storage.
+- Production API URL switching needs browser proof against `https://annotated-canvas-api.jaybhagat841.workers.dev`.

--- a/docs/cloudflare-cli.md
+++ b/docs/cloudflare-cli.md
@@ -77,6 +77,28 @@ npm run cf:deploy:production
 
 The first production setup created D1 `84bcbb47-3471-4a78-a99d-1f02c19bb2d9`, KV `46ef271ad63242ea86c3a657f05fa556`, Queues `annotated-canvas-jobs` and `annotated-canvas-dlq`, Worker `annotated-canvas-api`, and Pages project `annotated-canvas`. The live URLs are `https://annotated-canvas-api.jaybhagat841.workers.dev` and `https://annotated-canvas.pages.dev`. R2 returned Cloudflare API code `10042` because R2 is not enabled for the account; production omits the R2 binding until the audio-commentary storage issue is completed.
 
+## Dependency Handoff Gates
+
+Full gate sequencing is in `output/reports/gas-town/dependency-gate-map.md`. For the CLI lane, the highest priority external gate is proving deploy-from-main through GitHub Actions:
+
+```bash
+export CLOUDFLARE_ACCOUNT_ID=...
+export CLOUDFLARE_API_TOKEN=...
+npm run cf:setup:production -- --apply --github
+gh workflow run "CI and Deploy" --ref main -f deploy_production=true
+```
+
+This is HITL-required because the token value and approval to enable `CLOUDFLARE_DEPLOY_ENABLED=true` must come from the account owner. Without those credentials, engineers can still run dry runs, verify workflow conditions, update docs, and confirm the latest verification job status.
+
+Auth and media gates are separate:
+
+- Google callback URL: `https://annotated-canvas-api.jaybhagat841.workers.dev/api/auth/google/callback`.
+- X callback URL: `https://annotated-canvas-api.jaybhagat841.workers.dev/api/auth/x/callback`.
+- R2 bucket name, if enabled: `annotated-canvas-media`.
+- Worker binding to restore after storage exists: `MEDIA_BUCKET`.
+
+Do not install OAuth provider secrets until #24 has finalized the production secret names and token-exchange implementation. Do not restore the production R2 binding until R2 is enabled or an alternate storage path has been chosen.
+
 Local OAuth is optional and mainly useful when an engineer wants an interactive fallback session:
 
 ```bash

--- a/docs/deployment-devops.md
+++ b/docs/deployment-devops.md
@@ -252,6 +252,20 @@ Post-deploy smoke gate:
 - File a claim and verify content is not automatically removed.
 - Enqueue a duplicate background job and verify no duplicate side effects.
 
+## External Dependency Gate Map
+
+The current dependency sequence is captured in `output/reports/gas-town/dependency-gate-map.md`. Use that artifact as the handoff map for #22/#26 and the related #24 auth dependency.
+
+Order the remaining external gates this way:
+
+1. Prove deploy-from-main through GitHub Actions for #22.
+2. Finish no-credential auth hardening, then install Google/X provider apps and secrets for #24.
+3. Enable R2 or choose an alternate audio storage path for #26.
+4. Finalize the owned-media 240p/sub-480p policy for #26.
+5. Update the submission packet and submit only with completed gates or explicit known-limitations disclosure.
+
+No-credential work can continue on docs, dry runs, tests, fail-closed auth behavior, upload validation, and policy text. HITL work starts when secrets, account-level product enablement, provider app configuration, or product/legal media-policy decisions are needed.
+
 ## Current Production Status And Remaining Blockers
 
 - `apps/api/wrangler.production.jsonc` has production D1 and KV IDs for the `Jaybhagat841@gmail.com's Account` Cloudflare account.
@@ -266,3 +280,4 @@ Post-deploy smoke gate:
 - Preview/staging environments are not yet configured in Wrangler.
 - Remote migration execution uses `apps/api/migrations/production`, so `0002_seed_demo.sql` is not part of production deployment.
 - R2 is not enabled for the Cloudflare account yet. Production deploy omits the `MEDIA_BUCKET` binding, so audio commentary returns an upload intent instead of storing audio until #26 enables R2 or another storage path.
+- Google/X provider apps and secrets are not installed yet. #24 must also finalize real token exchange, session hardening, and extension handoff before credentials can close auth.

--- a/docs/submission-packet.md
+++ b/docs/submission-packet.md
@@ -68,8 +68,9 @@ Expected service name: `annotated-canvas-api`.
 5. Select the generated `dist/extension` folder.
 6. Open an article, video, podcast page, or another source page.
 7. Open the Annotated Canvas side panel from the extension icon.
-8. Use the capture controls to create a text selection or time-range annotation with commentary.
-9. After rebuilding, return to `chrome://extensions` and reload the extension card.
+8. In Settings, set `API URL` to `https://annotated-canvas-api.jaybhagat841.workers.dev` for production proof, then click `Save settings`.
+9. Use the capture controls to create a text selection or time-range annotation with commentary.
+10. After rebuilding, return to `chrome://extensions` and reload the extension card.
 
 ## Demo Script
 
@@ -193,6 +194,14 @@ Local Chrome evidence recorded in #30:
 - Current-page capture on `http://127.0.0.1:5173/` published into the local Worker API.
 - `GET /api/feed` returned `ann_e496763a-fb93-457b-a3f7-a6659d4f3e9d` with the expected active-tab source and commentary.
 
+Production extension p50/p95 proof still to record:
+
+- p50: reload the newly built `dist/extension`, save `https://annotated-canvas-api.jaybhagat841.workers.dev` in Settings, publish one <=90-second annotation from a real tab, and verify the annotation id through production API/feed/permalink evidence.
+- p95 selected text: select an exact quote on a normal HTTPS page, choose `Annotate selected text`, and retain the selected text screenshot, side-panel quote preview, production `POST /api/annotations` payload, response id, and stored annotation proof showing the same quote.
+- p95 media time: seek a real `<video>` or `<audio>` element, record `document.querySelector("video,audio")?.currentTime`, verify side-panel `Start` seeds from that value, publish <=90 seconds, and retain the production payload with exact `start_seconds`, `end_seconds`, and `duration_seconds`.
+- p95 over-90 rejection: enter a range longer than 90 seconds, retain the side-panel error `Clip length must be 90 seconds or less.`, and retain Network/HAR proof that no production `POST /api/annotations` was sent.
+- p95 audio/R2 limitation: record the microphone prompt outcome and the production `POST /api/uploads/audio-commentary` response. Current expected limitation is `upload.status: "intent-created"` rather than `"stored"` because production omits `MEDIA_BUCKET` until #26 enables R2 or another durable audio path.
+
 Production smoke evidence recorded on May 1, 2026:
 
 - `GET https://annotated-canvas-api.jaybhagat841.workers.dev/api/health` returned `200`.
@@ -213,6 +222,16 @@ Production smoke evidence recorded on May 1, 2026:
 - R2 is not enabled in the Cloudflare account yet. Production omits the R2 binding, so audio upload storage remains blocked by #26.
 - Chrome Web Store distribution is not part of the local MVP; reviewers load `dist/extension` unpacked.
 
+Dependency gate map: `output/reports/gas-town/dependency-gate-map.md`.
+
+External inputs required before this packet can claim full bounty coverage:
+
+- Cloudflare account ID and scoped API token approved for GitHub `production` secrets, plus approval to set `CLOUDFLARE_DEPLOY_ENABLED=true` and prove deploy-from-main.
+- Google OAuth app credentials for `https://annotated-canvas-api.jaybhagat841.workers.dev/api/auth/google/callback`.
+- X OAuth app credentials for `https://annotated-canvas-api.jaybhagat841.workers.dev/api/auth/x/callback`.
+- R2 enablement for bucket `annotated-canvas-media`, or an approved alternate storage path for recorded audio commentary.
+- Product/legal decision for third-party reference-only media versus owned-video 240p/sub-480p processing.
+
 ## Final Submission Checklist
 
 - [x] Public web URL is live and replaces the placeholder above.
@@ -220,12 +239,17 @@ Production smoke evidence recorded on May 1, 2026:
 - [x] Public feed, profile, permalink, removed state, and claim flow are smoke-tested.
 - [x] Chrome extension builds with `npm run build:extension`.
 - [x] Unpacked extension loads from `dist/extension` and side panel opens in Chrome.
+- [ ] Extension Settings saves the production Worker URL and publishes through that API base without source edits.
 - [ ] Current-page capture publishes the exact selected text or media time range.
+- [ ] Selected-text context menu proof includes exact quote preservation in the production payload and stored annotation.
+- [ ] Real media current-time proof includes browser `currentTime`, seeded side-panel fields, and exact production payload media seconds.
 - [ ] URL-input capture publishes with the original `source_url`.
 - [x] Media duration over 90 seconds is rejected.
+- [ ] Browser p95 proof shows over-90-second extension publish is blocked before any production network request.
 - [x] Every public annotation links back to its original source.
 - [x] Comments and engagement are demonstrated on a public annotation.
 - [x] `File a claim` records a notice and does not automatically remove content.
+- [ ] Audio commentary limitation is documented with microphone/upload evidence and the production R2 `intent-created` fallback.
 - [ ] Demo Google and X auth behavior is documented, or production OAuth is fully configured.
 - [ ] Known limitations are copied into the bounty submission without hiding bounty-critical gaps.
 - [ ] Submission is posted to `https://annotated.lovable.app`.

--- a/output/reports/gas-town/dependency-gate-map.md
+++ b/output/reports/gas-town/dependency-gate-map.md
@@ -1,0 +1,65 @@
+# Dependency Gate Map For #22/#26
+
+Generated May 1, 2026 for Worker D. Scope is documentation/evidence only: Cloudflare deploy-from-main, Google/X OAuth app credentials, R2 or alternate storage, and the 240p owned-media policy.
+
+## Current State
+
+- #22: production is live through local Wrangler proof. Worker, Pages, D1, KV, Queues, and public smoke evidence exist. The GitHub Actions deploy job still skips because `CLOUDFLARE_DEPLOY_ENABLED` is not `true` and the GitHub `production` environment does not yet have Cloudflare credentials.
+- #24 dependency: production config has `AUTH_MODE=oauth`, but real provider exchange is not done. Current Worker env typing recognizes `GOOGLE_CLIENT_ID` and `X_CLIENT_ID`; #24 still needs no-credential auth hardening and a final secret-name contract for provider secrets before credentials can close the issue.
+- #26: audio upload can return an intent and stores to R2 only when `MEDIA_BUCKET` exists. Production intentionally omits `MEDIA_BUCKET` because `wrangler r2 bucket create annotated-canvas-media --location enam` failed with Cloudflare API code `10042`, meaning R2 is not enabled for the account.
+- Submission packet: live URLs and smoke proof exist, but final bounty submission must either finish or disclose real OAuth, exact capture proof, audio storage, and 240p owned-media limitations.
+
+## Sequenced Gates
+
+| Gate | Dependency | Can proceed without credentials | HITL-required input | Done when | Blocks |
+| --- | --- | --- | --- | --- | --- |
+| 0 | Repo evidence preflight | Keep docs, issue comments, smoke commands, and known-limitations packet current. Verify latest CI run and config names. | None. | The dependency map and issue comments identify exact blockers. | Prevents ambiguous handoffs. |
+| 1 | Cloudflare deploy-from-main for #22 | Keep `npm run cf:setup:production -- --github` dry-run docs current. Confirm production config has real D1/KV IDs. Confirm workflow condition still gates on `CLOUDFLARE_DEPLOY_ENABLED`. | Cloudflare account ID and scoped API token. Approval to store both as GitHub `production` environment secrets and set repo variable `CLOUDFLARE_DEPLOY_ENABLED=true`. | A push or manual `gh workflow run "CI and Deploy" --ref main -f deploy_production=true` runs the deploy job instead of skipping, and post-deploy smoke passes. | #22 close. Final submission confidence. |
+| 2 | Google/X OAuth apps and secrets for #24 | Worker A/B can finish fail-closed auth behavior, state replay protection, token/profile mocking, session lookup/create, extension-token auth, and tests without provider credentials. Docs can list callback URLs. | Google OAuth app and X OAuth app with client IDs/secrets, authorized callback URLs, approved scopes, and permission to install provider config as Worker/GitHub secrets. | Production `/api/auth/google/start` and `/api/auth/x/start` redirect to providers, callbacks exchange codes, sessions are created, and extension handoff is smoke-tested. | Account-via-X/Google bounty criterion. |
+| 3 | R2 enablement or alternate audio storage for #26 | Keep third-party media source-linked. Harden upload validation and metadata/finalize tests in code lanes without production storage. Document truthful `intent-created` fallback. | Enable R2 on the Cloudflare account, or choose an alternate storage provider/path for audio commentary. If R2: approve bucket `annotated-canvas-media` and production binding `MEDIA_BUCKET`. | `POST /api/uploads/audio-commentary` returns `stored` or a real finalized asset path in production, and permalink playback/loading is proven. | Audio commentary storage and #26 close. |
+| 4 | 240p owned-media policy for #26 | Document the rights-safe default: third-party media is never copied or transcoded; it is referenced by original source URL plus start/end time. Draft owned-upload acceptance tests and disclosure copy. | Product/legal decision for owned uploads: whether owned video is in MVP, whether originals may be retained, whether the served rendition must be capped at 240p or merely below 480p, and which service enforces that policy. | Submission packet states the final policy, and any owned-video demo either serves only the approved low-resolution rendition or is explicitly out of scope. | 240p/sub-480p bounty criterion. |
+| 5 | Final submission gate | Keep the packet honest with current live URLs, smoke IDs, and known limitations. | Human approval to submit with either completed gates or explicit limitations. | `docs/submission-packet.md` matches the real deployed state and is posted to `annotated.lovable.app`. | #28 and #21 rollup. |
+
+## Exact Human Inputs Needed
+
+1. Cloudflare deployment credential handoff:
+   - `CLOUDFLARE_ACCOUNT_ID` for the account that owns `annotated-canvas-api`, `annotated-canvas`, `annotated_canvas`, and `SESSION_KV`.
+   - A scoped `CLOUDFLARE_API_TOKEN` with Workers Scripts edit, Pages edit, D1 edit, KV edit, Queues edit, R2 edit if R2 will be enabled, Account Settings read, and Durable Objects migration permissions through Worker deploy.
+   - Approval to store those values in the GitHub `production` environment and to set repository variable `CLOUDFLARE_DEPLOY_ENABLED=true`.
+   - Approval to trigger or wait for the next `main` deploy workflow and run public smoke checks afterward.
+
+2. Google OAuth app handoff:
+   - Google OAuth client ID and client secret for production.
+   - Authorized redirect URI: `https://annotated-canvas-api.jaybhagat841.workers.dev/api/auth/google/callback`.
+   - Approved scopes: `openid email profile`.
+   - Confirmation of the production app/homepage URL: `https://annotated-canvas.pages.dev`.
+
+3. X OAuth app handoff:
+   - X OAuth client ID and client secret for production.
+   - Authorized callback URL: `https://annotated-canvas-api.jaybhagat841.workers.dev/api/auth/x/callback`.
+   - Approved scopes matching the route contract: `users.read tweet.read`.
+   - Confirmation whether X requires PKCE-only public-client handling or a confidential client secret for this app. #24 must align code and secret names before install.
+
+4. Storage decision:
+   - Either enable Cloudflare R2 for the account and approve bucket `annotated-canvas-media`, or name the alternate storage path for recorded audio commentary.
+   - Decide whether commentary audio assets are public, signed, or proxied through the Worker.
+   - If R2 is enabled, approve restoring the production `MEDIA_BUCKET` binding and running a production deploy.
+
+5. Owned-media 240p policy:
+   - Confirm that third-party YouTube/news/podcast/video clips stay reference-only and are not copied into R2/Stream.
+   - Decide whether owned video upload is included in the MVP submission.
+   - If included, specify the enforcement rule: reject >240p input, store original privately and serve a <=240p rendition, or use another under-480p rule.
+   - Provide the disclosure wording for the bounty packet if owned-video processing is not completed before submission.
+
+## Close Criteria By Issue
+
+- #22 can close after deploy-from-main is proven by GitHub Actions and public smoke passes from that deployed commit.
+- #24 can close only after no-credential auth hardening lands and real Google/X provider flows are configured and smoke-tested.
+- #26 can close only after production audio storage/finalize works and the 240p owned-media policy is implemented or explicitly scoped with accepted disclosure.
+- #28/#21 should not close while any bounty-critical gate is unfinished or undisclosed.
+
+## GitHub Comments Posted
+
+- #22 deploy-from-main gate: https://github.com/ChaiWithJai/annotated-canvas/issues/22#issuecomment-4357654808
+- #26 R2/audio/240p gate: https://github.com/ChaiWithJai/annotated-canvas/issues/26#issuecomment-4357655205
+- #24 cross-lane OAuth dependency note: https://github.com/ChaiWithJai/annotated-canvas/issues/24#issuecomment-4357655497

--- a/output/reports/gas-town/issue-23-30-extension-production-smoke-plan.md
+++ b/output/reports/gas-town/issue-23-30-extension-production-smoke-plan.md
@@ -1,0 +1,51 @@
+# Issue #23/#30 Extension Production Smoke Plan
+
+Prepared for Worker C on May 1, 2026. This plan is based on the open #23/#30 issue comments and the current docs packet.
+
+## Production Target
+
+- Worker API base: `https://annotated-canvas-api.jaybhagat841.workers.dev`
+- Health check: `GET /api/health`
+- Observed baseline on May 1, 2026: `200` with `ok: true`, `service: annotated-canvas-api`, and `mode: production`.
+
+## p50 Sequence
+
+1. Build and reload the extension.
+   - Evidence: `npm run build:extension` output, `ls -1 dist/extension`, and `chrome://extensions` screenshot showing the unpacked `Annotated Canvas` card.
+2. Save the production API base.
+   - Evidence: side-panel Settings before/after, `Save settings` -> `Saved.`, reopened Settings still showing `https://annotated-canvas-api.jaybhagat841.workers.dev`, and production health check output.
+3. Publish one happy-path annotation from a real tab.
+   - Evidence: side panel source title/domain, `POST /api/annotations` sent to the production Worker, request payload with `client_context.surface: "extension"`, response annotation id, and feed/permalink/API proof for the id.
+
+## p95 Sequence
+
+1. Selected-text context menu proof.
+   - Steps: select an exact quote, right-click, choose `Annotate selected text`, confirm the side panel switches to `Selected text`, publish.
+   - Evidence: selected quote screenshot, context menu item screenshot, side-panel quote preview, production request payload with `clip.kind: "text"`, exact `clip.text.quote`, `client_context.capture_method: "selection"`, response id, and stored annotation proof preserving the quote.
+2. Real media current-time proof.
+   - Steps: open a page with a real top-level `<video>` or `<audio>`, seek to a known time, record `document.querySelector("video,audio")?.currentTime`, open side panel, publish <=90 seconds.
+   - Evidence: media page URL/title, console/current-time proof, side-panel `Start` and `End`, production request payload with `clip.kind` `video` or `audio`, exact `media.start_seconds`, `media.end_seconds`, `media.duration_seconds`, and stored annotation proof.
+3. Over-90-second browser rejection.
+   - Steps: clear Network, enter a range longer than 90 seconds, click `Publish annotation`.
+   - Evidence: fields showing the >90 range, error text `Clip length must be 90 seconds or less.`, and Network/HAR proof that no production `POST /api/annotations` fired.
+4. Audio/R2 limitation.
+   - Steps: click `Record voice note`, handle the microphone prompt, stop recording if allowed, publish or call the upload endpoint directly.
+   - Evidence: microphone prompt or `Microphone permission was blocked.`, `Voice note ready` if allowed, production `POST /api/uploads/audio-commentary` response with `upload.storage: "r2"` and `upload.status: "intent-created"` rather than `"stored"`, plus a limitation note that #26 owns durable R2/audio storage.
+
+## Issue Comment Draft
+
+Use this if posting a coordination update to #30, and optionally cross-link it in #23:
+
+```md
+Worker C planning update for the production extension smoke:
+
+The p50 path is: rebuild/reload `dist/extension`, save `https://annotated-canvas-api.jaybhagat841.workers.dev` in Settings, publish one <=90-second annotation from a real tab, and verify the annotation id through production API/feed/permalink evidence.
+
+The p95 path should then capture:
+- selected-text context menu proof with exact quote preservation in the production `POST /api/annotations` payload and stored annotation;
+- real `<video>`/`<audio>` current-time proof with console `currentTime`, seeded side-panel `Start`/`End`, and exact media seconds in the payload;
+- >90-second browser rejection with the error `Clip length must be 90 seconds or less.` and Network/HAR proof that no production publish request fired;
+- audio/R2 limitation proof with microphone prompt outcome and `POST /api/uploads/audio-commentary` returning `upload.status: "intent-created"` rather than `"stored"` until #26 enables durable storage.
+
+Docs updated: `docs/chrome-extension-local-smoke.md` and `docs/submission-packet.md`.
+```

--- a/output/reports/gas-town/issue_execution_plan.json
+++ b/output/reports/gas-town/issue_execution_plan.json
@@ -1,0 +1,51 @@
+[
+  {
+    "issue": 24,
+    "priority": "P0",
+    "status": "no_credential_slice_implemented_external_oauth_required",
+    "why": "Visible sign-in controls are not wired to a credible auth flow; production auth falls back instead of failing closed when provider config is missing.",
+    "deliverable": "Backend auth now fails closed, validates state/session boundaries, and web sign-in now calls the API with inline errors. Real provider exchange remains blocked on external OAuth apps/secrets."
+  },
+  {
+    "issue": 23,
+    "priority": "P0",
+    "status": "next",
+    "why": "Capture is mostly implemented but still needs browser-level payload proof across selected text and media timecode.",
+    "deliverable": "Browser evidence and issue packet updates after auth slice."
+  },
+  {
+    "issue": 30,
+    "priority": "P0",
+    "status": "next",
+    "why": "Extension reviewer proof remains incomplete against production Worker URL and p95 capture cases.",
+    "deliverable": "Computer Use/Chrome smoke against production API settings, selected text, media current time, over-90 rejection."
+  },
+  {
+    "issue": 22,
+    "priority": "P0",
+    "status": "blocked_external_secret",
+    "why": "Local Cloudflare deployment is live; GitHub deploy-from-main remains skipped without scoped Cloudflare API token.",
+    "deliverable": "Store production secrets/vars and prove GitHub Actions deploy job runs."
+  },
+  {
+    "issue": 21,
+    "priority": "P0",
+    "status": "rollup_open",
+    "why": "Bounty rollup cannot close while #24/#23/#30/#26/#22 remain open.",
+    "deliverable": "Close only after child issues and final submission evidence converge."
+  },
+  {
+    "issue": 26,
+    "priority": "P1",
+    "status": "blocked_platform_plus_code",
+    "why": "R2 disabled; audio storage/finalize and 240p owned-media policy incomplete.",
+    "deliverable": "Enable/replace storage, restore binding, implement finalize/tests/policy."
+  },
+  {
+    "issue": 28,
+    "priority": "P1",
+    "status": "blocked_by_product_gaps",
+    "why": "Packet has live URLs, but sign-in/capture/audio gaps must be fixed or disclosed before external submission.",
+    "deliverable": "Final reviewer script and submission after core gaps are resolved."
+  }
+]

--- a/output/reports/gas-town/issue_execution_plan.md
+++ b/output/reports/gas-town/issue_execution_plan.md
@@ -1,0 +1,57 @@
+# Gas Town Issue Execution Plan
+
+Generated from open issue bodies and comments.
+
+## Parallel Lanes
+- Worker A / Boyle: #24 backend auth hardening; owns API/auth files.
+- Worker B / Euler: #24 web sign-in UX; owns web UI/API client files.
+- Worker C / Bernoulli: #23/#30 extension p50/p95 proof checklist; owns docs/evidence.
+- Worker D / Mencius: #22/#26 dependency gate map; owns docs/evidence.
+- Orchestrator: integrate non-overlapping changes, run gates, update GitHub issues, and decide what can close.
+
+## #24 Epic: Real X/Google auth and extension handoff
+- Priority: P0
+- Status: no-credential slice implemented; external OAuth apps/secrets still required
+- Why: Visible sign-in controls are not wired to a credible auth flow; production auth falls back instead of failing closed when provider config is missing.
+- Deliverable: No-credential auth hardening plus web sign-in action/status; keep real provider exchange blocked on external secrets.
+- Close gate: browser click on sign-in produces a visible network-backed result; production without provider secrets fails clearly; demo mode still works locally; oauth mode does not mint fake sessions.
+
+## #23 Epic: Complete extension and web capture journey
+- Priority: P0
+- Status: next
+- Why: Capture is mostly implemented but still needs browser-level payload proof across selected text and media timecode.
+- Deliverable: Browser evidence and issue packet updates after auth slice.
+- Close gate: recorded evidence shows exact selected text and exact media range in the API payload from an unpacked extension.
+
+## #30 Task: Local Chrome extension install and bounty smoke verification
+- Priority: P0
+- Status: next
+- Why: Extension reviewer proof remains incomplete against production Worker URL and p95 capture cases.
+- Deliverable: Computer Use/Chrome smoke against production API settings, selected text, media current time, over-90 rejection.
+- Close gate: reviewer can reproduce install, production API base switch, publish success, and rejection of invalid media range from Chrome.
+
+## #22 Epic: Cloudflare CLI production setup and deployment
+- Priority: P0
+- Status: blocked_external_secret
+- Why: Local Cloudflare deployment is live; GitHub deploy-from-main remains skipped without scoped Cloudflare API token.
+- Deliverable: Store production secrets/vars and prove GitHub Actions deploy job runs.
+- Close gate: GitHub Actions deploy job runs on main and deploys Worker/Pages after green tests.
+
+## #21 Epic: Bounty gap audit and submission readiness
+- Priority: P0
+- Status: rollup_open
+- Why: Bounty rollup cannot close while #24/#23/#30/#26/#22 remain open.
+- Deliverable: Close only after child issues and final submission evidence converge.
+
+## #26 Epic: Audio commentary and 240p media policy
+- Priority: P1
+- Status: blocked_platform_plus_code
+- Why: R2 disabled; audio storage/finalize and 240p owned-media policy incomplete.
+- Deliverable: Enable/replace storage, restore binding, implement finalize/tests/policy.
+- Close gate: audio asset persists and loads from permalink, and owned-media downscale policy is implemented or explicitly scoped out with a bounty-safe rationale.
+
+## #28 Task: Prepare final bounty submission package
+- Priority: P1
+- Status: blocked_by_product_gaps
+- Why: Packet has live URLs, but sign-in/capture/audio gaps must be fixed or disclosed before external submission.
+- Deliverable: Final reviewer script and submission after core gaps are resolved.

--- a/output/reports/gas-town/open_issues_with_comments.json
+++ b/output/reports/gas-town/open_issues_with_comments.json
@@ -1,0 +1,788 @@
+[
+  {
+    "body": "Parent: #23, #21\n\n## Bounty discrepancy\n\nThe extension can be built locally, but we do not yet have browser-level proof that a reviewer can load the unpacked MV3 extension, capture a real tab, publish through the configured API target, and see the result in the web feed/permalink.\n\n## Learning objective\n\nTurn the extension from code-complete into reviewer-verifiable software. Document every Chrome extension pitfall, local setup step, permission prompt, API target decision, and smoke-test artifact so the bounty reviewer can reproduce the path without store approval.\n\n## Practice task\n\nUse Computer Use or Playwright/browser automation where practical to load the built Chrome extension locally and run the full capture flow against the local or deployed API. Capture evidence and update the submission packet with exact reviewer steps.\n\n## Acceptance criteria\n\n- [ ] `npm run build:extension` creates a loadable unpacked extension directory.\n- [ ] Reviewer install steps identify the exact Chrome page, folder, permissions, and refresh behavior.\n- [ ] Extension settings or build config can point to localhost and production Worker API without source edits.\n- [ ] Smoke test captures current tab URL/title and selected text from a real browser page.\n- [ ] Smoke test captures a media time range and enforces the 90-second cap before network publish.\n- [ ] Smoke test publishes through the API and verifies the new annotation appears in the web client/feed or API response.\n- [ ] Audio commentary path is tested or explicitly documented as blocked by browser/microphone/R2 constraints.\n- [ ] Evidence is attached or linked in #28 submission packet.\n- [ ] Learning log documents extension-specific pitfalls such as MV3 side panel access, localhost CORS, host permissions, reload-after-build, and production API base switching.\n\n## Roadblocks and learning log\n\n- Current roadblock: public deploy URL is not available yet; local smoke can proceed against `http://localhost:8787`.\n- Pitfall to test: an unpacked extension cannot assume localhost in review builds; the API base must be configurable or injected at build time.\n- Pitfall to test: Chrome extension permissions and side panel behavior differ from normal web app Playwright flows, so Computer Use may be needed for final manual proof.\n",
+    "comments": [
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7jTDA",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Static inspection and local smoke prep for #30 is ready. I added `docs/chrome-extension-local-smoke.md` with the reviewer install path, smoke checklist, evidence requirements, bounty mapping, and learning-log pitfalls.\n\n## Static findings\n\n- Source manifest: `apps/extension/public/manifest.json`\n- Expected unpacked directory: `dist/extension` from `npm run build:extension`\n- MV3 manifest shape: `manifest_version: 3`, `name: Annotated Canvas`, `minimum_chrome_version: 116`\n- Entrypoints: `service-worker.js`, `sidepanel.html`, `content-script.js`\n- Permissions: `sidePanel`, `scripting`, `storage`, `tabs`, `contextMenus`, `identity`; host permissions are `<all_urls>`\n- API base behavior: default `http://localhost:8787`; side panel Settings persists `apiBaseUrl` in `chrome.storage.local`, so localhost vs production Worker switching should not require a source edit.\n\n## Acceptance criteria mapping\n\n- Build/loadable artifact: run `npm run build:extension`, then load `dist/extension` in Chrome.\n- Exact reviewer install steps: `chrome://extensions` -> Developer mode -> Load unpacked -> select `dist/extension` -> reload the extension card after rebuilds.\n- API target switching: verify Settings saves localhost and deployed Worker origins.\n- Current tab capture: verify active tab URL/title via content script or tab fallback on a real page.\n- Selected text capture: select text, use the `Annotate selected text` context menu, and confirm the side panel shows the selected text path.\n- Media capture and 90-second cap: verify media time range seeds from a real audio/video page where available, and that >90 seconds is blocked before network publish.\n- Publish proof: publish <=90 seconds through local or deployed API and verify the annotation in feed/web/API response.\n- Audio commentary: test microphone + upload path, or document the exact browser/upload/R2 blocker.\n- Submission packet evidence: attach screenshots/recordings/API ids to #28 after browser verification.\n\n## Bounty criteria smoke proof\n\n| Requirement | Proof to capture |\n| --- | --- |\n| Sidebar Chrome extension | `dist/extension` loads unpacked and opens the MV3 side panel. |\n| Highlight/clip media from any website | Selected text path plus media URL/title/time range capture from a real page. |\n| Add commentary/annotations | Side panel commentary posts to `POST /api/annotations`. |\n| Public feed | Published annotation appears in web feed/permalink or API feed response. |\n| URL/current page | Extension reads active tab URL/title without manual source entry. |\n| 90-second max | Side panel blocks >90s media ranges before network publish. |\n| Audio commentary | Voice note publish proof, or precise microphone/upload blocker. |\n\n## Learning-log pitfalls to capture\n\n- MV3 side panel testing differs from normal web-app browser automation.\n- Reload the unpacked extension at `chrome://extensions` after every rebuild.\n- Load `dist/extension`, not `apps/extension`.\n- Verify localhost CORS and extension host permissions together.\n- Treat context-menu selected text and active-tab content-script reads as separate capture paths.\n- Keep API base switching configurable without source edits.\n- Microphone permissions and upload storage can block audio commentary independently from text/media publishing.\n\n## Blocker for main thread/browser automation\n\nI started `npm run build:extension`; it reached Vite `transforming...` output but did not complete before being stopped per coordination instruction. A `dist/extension` directory is present locally with the expected manifest/file shape, and I validated the manifest keys statically, but final evidence should rerun the build from a clean state and then load Chrome manually/with the main thread automation. No Computer Use was used here.",
+        "createdAt": "2026-05-01T02:11:14Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/30#issuecomment-4357411596",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7onQw",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Build/test blocker update from main thread:\n\n- Reproduced the extension/web build hang under Vite 8.0.10; sampling showed the process blocked inside native `rolldown-worker` threads.\n- Pinned the repo back to Vite 7.3.2 with `@vitejs/plugin-react` 5.2.0, which restored deterministic Rollup-based builds.\n- Split `npm test` into node logic tests plus a separate happy-dom web UI test to avoid Vitest worker startup timeouts.\n- Added extension Settings API URL persistence so local review can target `http://localhost:8787` and production review can target the deployed Worker without source edits.\n\nVerified locally after the fix:\n- `npm run typecheck`\n- `npm test` -> 4 files, 31 tests passing\n- `npm run test:workers` -> 1 Worker-runtime test passing; workerd still prints the known WebSocket disconnect message after success\n- `npm run build` -> web and extension artifacts build cleanly under `dist/web` and `dist/extension`\n\nNext evidence step remains browser-level proof: load `dist/extension` unpacked in Chrome, open the side panel, set/confirm API URL, capture selected text/time range, publish, and verify the API/web feed response.",
+        "createdAt": "2026-05-01T02:40:18Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/30#issuecomment-4357498691",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7pjFQ",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "## Local Chrome extension browser smoke update\n\nVerified with Computer Use in desktop Chrome:\n\n- Loaded `dist/extension` through `chrome://extensions` with Developer Mode enabled.\n- Confirmed extension card: `Annotated Canvas 0.1.0`, extension ID `knpgndejanjcgnfognmebiieingaimkl`.\n- Pinned the extension to the toolbar.\n- Opened the MV3 side panel from the extension action.\n- Verified Settings shows `http://localhost:8787` and Save settings returns `Saved.`.\n- Opened the local web client at `http://127.0.0.1:5173/`, reopened the extension, and confirmed the side panel captured the active tab source as `Annotated Canvas` / `http://127.0.0.1:5173/`.\n- Published a 47-second time range from the extension side panel into the local Worker API.\n- Verified `GET /api/feed` contains the created annotation:\n  - id: `ann_e496763a-fb93-457b-a3f7-a6659d4f3e9d`\n  - source_url: `http://127.0.0.1:5173/`\n  - source_domain: `127.0.0.1`\n  - commentary: `Local extension smoke test for bounty criteria: capture from active tab to local API.`\n\nRegression gates passed before browser smoke:\n\n- `npm run typecheck`\n- `npm test`\n- `npm run test:workers`\n- `npm run build`\n\nRemaining p95 smoke gaps before this can close:\n\n- Selected-text context menu capture on a normal content page.\n- Real video/audio current-time capture.\n- Browser proof for >90 second client-side validation.\n- Microphone + audio commentary upload proof.\n- Production Worker URL save/switch after Cloudflare deployment exists.\n\nI also updated `docs/chrome-extension-local-smoke.md` with the verified evidence and remaining gaps.\n",
+        "createdAt": "2026-05-01T02:45:50Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/30#issuecomment-4357514005",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7qu5g",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "## Commit and CI update\n\nThe local extension smoke work is now on `main` in commit `49ddf78`.\n\nGitHub Actions run `25199948055` passed verification after the push:\n\n- typecheck\n- unit/integration tests\n- Worker runtime tests\n- production builds\n\nThis issue should remain open until the remaining p95 extension smoke items are proven or explicitly split out:\n\n- selected-text context menu capture\n- real media current-time capture\n- over-90-second browser validation\n- audio commentary/microphone/upload proof\n- production Worker API URL switching after deploy\n",
+        "createdAt": "2026-05-01T02:52:17Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/30#issuecomment-4357533414",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7wL5w",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Chrome extension status after the deployment pass, May 1, 2026:\n\nDone/proven:\n- `npm run build` passed, including `npm run build:extension`.\n- Prior local Chrome proof loaded `dist/extension` unpacked, opened the side panel, saved `http://localhost:8787`, captured the active tab, and published a local smoke annotation.\n\nStill required before closing this ticket:\n- Reload the newly rebuilt `dist/extension` artifact and run the same smoke against the production Worker URL.\n- Prove selected-text context menu capture binds the exact quote into `POST /api/annotations`.\n- Prove real media current-time capture binds start/end/duration into the payload.\n- Prove >90-second media capture is rejected in the browser, not only in unit tests.\n- Record a reviewer-friendly clip or screenshot sequence for the bounty packet.\n\nLearning note: this is the boundary between p50 smoke and p95 confidence. A side panel opening and one current-page publish proves the path exists; it does not prove precision capture, rejected invalid duration, or reviewer repeatability.\n",
+        "createdAt": "2026-05-01T03:20:51Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/30#issuecomment-4357622759",
+        "viewerDidAuthor": true
+      }
+    ],
+    "labels": [
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnYYA",
+        "name": "type:task",
+        "description": "Concrete task with clear acceptance criteria",
+        "color": "0E8A16"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnZDw",
+        "name": "stream:chrome-extension",
+        "description": "Chrome extension and MV3 side panel stream",
+        "color": "5319E7"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnZTA",
+        "name": "area:chrome-extension",
+        "description": "MV3 extension, side panel, content scripts",
+        "color": "D4C5F9"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnaNA",
+        "name": "priority:p0",
+        "description": "Critical path for MVP scaffolding",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnaWg",
+        "name": "learning-log",
+        "description": "Issue must document learning, roadblocks, and pitfalls",
+        "color": "C5DEF5"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnanA",
+        "name": "risk:platform",
+        "description": "Platform constraint or integration risk",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChc33bg",
+        "name": "bounty:gap",
+        "description": "Gap found against bounty.txt requirements",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChc34KQ",
+        "name": "area:bounty-submission",
+        "description": "Submission readiness for the Annotated bounty",
+        "color": "FBCA04"
+      }
+    ],
+    "number": 30,
+    "state": "OPEN",
+    "title": "Task: Local Chrome extension install and bounty smoke verification",
+    "updatedAt": "2026-05-01T03:20:51Z",
+    "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/30"
+  },
+  {
+    "body": "Parent: #21\n\n## Bounty discrepancy\n\nThe bounty asks submissions to be posted to annotated.lovable.app. We need a concise submission package once deployment and core bounty flows are live.\n\n## Learning objective\n\nCreate a reviewer-friendly package that demonstrates the product against the bounty requirements with minimal setup friction.\n\n## Acceptance criteria\n\n- [ ] Public web URL is live.\n- [ ] Public API health URL is live.\n- [ ] Chrome extension local-install instructions are linked.\n- [ ] Demo script covers sign in, current-page capture, URL capture, text/video/audio commentary, feed, follow, comments, claim filing, and source links.\n- [ ] Known limitations are explicit and do not obscure bounty-critical behavior.\n- [ ] Submission checklist is posted to this issue before external submission.\n",
+    "comments": [
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7hqdw",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Closure audit, May 1 2026:\n\nKeep open. The final submission package is blocked on public deployment and production auth/media decisions.\n\nCurrent blocker evidence:\n- `wrangler whoami` reports not authenticated.\n- `apps/api/wrangler.production.jsonc` still has placeholder production D1/KV IDs.\n- `gh secret list`, `gh secret list --env production`, and `gh variable list` returned no configured secrets/vars.\n- Latest GitHub Actions verify run is green, but the production deploy job is skipped because the deploy gate/secrets/resources are not configured.\n\nNo-credential prep still worth doing:\n- Draft the reviewer demo script from the local flows: sign-in entry, URL capture, current-page capture, text annotation, media timecode annotation, audio commentary, feed, comment, follow, claim, source link.\n- Add a public smoke checklist for web root, `/api/health`, feed, permalink, comment POST/GET, claim POST/GET, and extension publish.\n- List known limitations honestly: demo/local auth until #24, third-party media by reference, owned-upload 240p pending #26, extension API base pending deployed URL.\n\nCredential/resource blockers: Cloudflare account/token, production D1/KV/R2/Queues/Pages resources, OAuth provider secrets, and final public URLs.\n",
+        "createdAt": "2026-05-01T02:02:08Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/28#issuecomment-4357384823",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7wJJw",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Submission packet update, May 1, 2026:\n\nLive reviewer links are now in `docs/submission-packet.md`:\n- Public web: https://annotated-canvas.pages.dev\n- API health: https://annotated-canvas-api.jaybhagat841.workers.dev/api/health\n- Feed: https://annotated-canvas.pages.dev/\n- Profile: https://annotated-canvas.pages.dev/u/mira\n- Permalink: https://annotated-canvas.pages.dev/a/ann_74ce284f-0516-41d1-a8f0-fdb0d3b824b0\n\nPublic smoke evidence:\n- Created production annotation `ann_74ce284f-0516-41d1-a8f0-fdb0d3b824b0`.\n- Confirmed API canonical `permalink_url` points to `annotated-canvas.pages.dev`.\n- Created public comment `cmt_73c82db2-d4db-4661-b92e-84b12b4e74e7`.\n- Created claim notice `claim_36899790-f89f-4add-9744-046b5b46c3f3`; the annotation stayed public afterward.\n- Audio upload endpoint returns `intent-created`, which documents the R2-disabled fallback instead of pretending audio storage is complete.\n\nWhat still must be disclosed or finished for a stronger bounty submission:\n- Real X/Google OAuth remains #24.\n- R2-backed audio commentary and 240p owned-media processing remain #26.\n- Exact selected-text/current-media capture proof remains #23/#30.\n- GitHub Actions deploy-from-main remains #22 until the Cloudflare API token is stored as a GitHub environment secret.\n",
+        "createdAt": "2026-05-01T03:20:36Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/28#issuecomment-4357622055",
+        "viewerDidAuthor": true
+      }
+    ],
+    "labels": [
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnSxg",
+        "name": "documentation",
+        "description": "Improvements or additions to documentation",
+        "color": "0075ca"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnYYA",
+        "name": "type:task",
+        "description": "Concrete task with clear acceptance criteria",
+        "color": "0E8A16"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnaSA",
+        "name": "priority:p1",
+        "description": "Next priority after P0",
+        "color": "D93F0B"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnaWg",
+        "name": "learning-log",
+        "description": "Issue must document learning, roadblocks, and pitfalls",
+        "color": "C5DEF5"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChc33bg",
+        "name": "bounty:gap",
+        "description": "Gap found against bounty.txt requirements",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChc34KQ",
+        "name": "area:bounty-submission",
+        "description": "Submission readiness for the Annotated bounty",
+        "color": "FBCA04"
+      }
+    ],
+    "number": 28,
+    "state": "OPEN",
+    "title": "Task: Prepare final bounty submission package",
+    "updatedAt": "2026-05-01T03:20:36Z",
+    "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/28"
+  },
+  {
+    "body": "Parent: #21\n\n## Bounty discrepancy\n\nThe bounty asks for text or recorded audio commentary and says clips should be downgraded to 240p below 480p. The current MVP supports text commentary and upload intents, but not recording/uploading audio commentary. Third-party media is intentionally stored by reference, so the 240p requirement needs a rights-safe implementation decision.\n\n## Learning objective\n\nSeparate source-linked third-party references from owned media processing, then implement audio commentary capture safely.\n\n## Acceptance criteria\n\n- [ ] Extension/web can record audio commentary using browser MediaRecorder where available.\n- [ ] API supports an upload/finalize path for audio commentary assets.\n- [ ] Annotation publish can reference finalized audio commentary.\n- [ ] Product decision records how 240p applies to third-party embeds versus owned uploads.\n- [ ] Owned video upload path documents or implements Cloudflare Stream transformation settings.\n- [ ] Regression tests cover missing audio asset, oversized audio, and source attribution preservation.\n\n## Roadblocks and learning log\n\n- Pitfall: copying third-party media into R2/Stream can create avoidable rights risk; link-first behavior must remain intact unless the user owns the upload.\n",
+    "comments": [
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7eAcg",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Partial progress landed locally:\n- Extension can record microphone audio with `MediaRecorder`.\n- Extension uploads recorded audio to `POST /api/uploads/audio-commentary` before publish.\n- API now returns audio upload asset metadata and stores to R2 when `MEDIA_BUCKET` exists.\n\nRemaining:\n- Production upload/finalize hardening.\n- Explicit 240p policy/implementation for owned uploads versus third-party source-linked references.\n- Browser verification for audio recording inside the unpacked extension.",
+        "createdAt": "2026-05-01T01:42:25Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/26#issuecomment-4357324914",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7ho9w",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Closure audit, May 1 2026:\n\nKeep open. Audio commentary is locally scaffolded, but the production asset boundary and 240p policy are not done enough for bounty-close confidence.\n\nNo-credential implementation remaining:\n- Enforce audio upload size/content-type before storage; today the route advertises `max_bytes` but does not reject oversized uploads before `MEDIA_BUCKET.put`.\n- Persist audio upload metadata or otherwise validate that `commentary.kind=audio` references a finalized audio asset, not just an arbitrary ID.\n- Add tests for missing audio asset, oversized audio, unsupported content type, and publish with stored audio commentary.\n- Record the product decision that third-party audio/video stays source-linked by reference, while 240p/downscale applies only to owned uploads.\n\nCredential/provider blockers:\n- Production R2 bucket and Worker binding for stored audio commentary.\n- Cloudflare Stream or equivalent owned-video upload/encoding settings if the owned-upload path is part of the bounty demo.\n\nRecommended MVP stance: do not copy third-party media. Demo third-party clips as source-linked references with start/end times, and treat 240p as an owned-upload processing rule.\n",
+        "createdAt": "2026-05-01T02:02:01Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/26#issuecomment-4357384439",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7wL5A",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Storage/audio status from the production pass, May 1, 2026:\n\nObserved platform constraint:\n- `wrangler r2 bucket create annotated-canvas-media --location enam` failed with Cloudflare API code `10042` because R2 is not enabled for the account.\n- The production Worker was deployed without the `MEDIA_BUCKET` binding so the rest of the MVP could ship.\n- `POST /api/uploads/audio-commentary` currently returns `status: intent-created`, which is a truthful fallback path, not completed audio storage.\n\nAcceptance criteria this issue still owns:\n- Enable R2 or choose an alternate storage path.\n- Restore the production `MEDIA_BUCKET` binding once storage exists.\n- Add audio recording/finalize UI in the extension/web surface.\n- Prove recorded audio commentary persists and can be loaded from a permalink.\n- Finalize the owned-media 240p/sub-480p processing policy rather than relying only on third-party source references.\n",
+        "createdAt": "2026-05-01T03:20:51Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/26#issuecomment-4357622756",
+        "viewerDidAuthor": true
+      }
+    ],
+    "labels": [
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnYQw",
+        "name": "type:epic",
+        "description": "Parent issue grouping related delivery work",
+        "color": "5319E7"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnZTA",
+        "name": "area:chrome-extension",
+        "description": "MV3 extension, side panel, content scripts",
+        "color": "D4C5F9"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnZ2A",
+        "name": "area:media",
+        "description": "Clip refs, uploads, source metadata, media policy",
+        "color": "FEF2C0"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnaSA",
+        "name": "priority:p1",
+        "description": "Next priority after P0",
+        "color": "D93F0B"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnaWg",
+        "name": "learning-log",
+        "description": "Issue must document learning, roadblocks, and pitfalls",
+        "color": "C5DEF5"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnadQ",
+        "name": "needs-research",
+        "description": "Requires research or explicit decision before coding",
+        "color": "D4C5F9"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnayg",
+        "name": "risk:legal-rights",
+        "description": "Rights, fair-use, attribution, or claims risk",
+        "color": "D93F0B"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChc33bg",
+        "name": "bounty:gap",
+        "description": "Gap found against bounty.txt requirements",
+        "color": "B60205"
+      }
+    ],
+    "number": 26,
+    "state": "OPEN",
+    "title": "Epic: Audio commentary and 240p media policy",
+    "updatedAt": "2026-05-01T03:20:51Z",
+    "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/26"
+  },
+  {
+    "body": "Parent: #21\n\n## Bounty discrepancy\n\nThe bounty requires account creation via X or Google. Current routes are demo-safe and generate authorization URLs when client IDs exist, but they do not perform provider token exchange, user creation, or a hardened extension handoff.\n\n## Learning objective\n\nImplement real OAuth boundaries while keeping local demo mode available for development.\n\n## Acceptance criteria\n\n- [ ] Google OAuth callback exchanges code for tokens and creates/loads a user.\n- [ ] X OAuth callback exchanges code for tokens and creates/loads a user.\n- [ ] Sessions are stored in KV/D1 with secure cookie settings for production.\n- [ ] Extension can request a short-lived token from an authenticated web session.\n- [ ] Tests cover invalid state, replayed state, unsupported provider, and logout.\n\n## Roadblocks and learning log\n\n- Roadblock: provider client IDs/secrets must be configured outside the repo.\n- Pitfall: demo OAuth must never run in production when `AUTH_MODE=oauth`.\n",
+    "comments": [
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7hnhA",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Closure audit, May 1 2026:\n\nKeep open. This is not only blocked on provider credentials; there is still minimal no-credential auth code to finish before real OAuth can be credible.\n\nNo-credential implementation remaining:\n- In `AUTH_MODE=oauth`, fail closed when provider client IDs/secrets are missing instead of falling back to the local callback URL.\n- Consume and delete stored OAuth state on callback, reject invalid/replayed state, and test both providers with mocked token/profile responses.\n- Replace the hardcoded `usr_demo` session creation with provider account lookup/create against D1 users/oauth_accounts/sessions.\n- Require a valid web session for `/api/auth/extension-token`; issue a short-lived token tied to that user/session; make logout remove/expire the session.\n- Add regression tests for unsupported provider, invalid state, replayed state, missing code, logout, and anonymous extension-token rejection.\n\nCredential/provider blockers:\n- Google OAuth app client ID/secret and callback URL.\n- X OAuth app client ID/secret and callback URL.\n- Production Cloudflare KV/D1 resources and Worker secrets for session/provider config.\n",
+        "createdAt": "2026-05-01T02:01:54Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/24#issuecomment-4357384068",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7wM5Q",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Auth status after production deploy, May 1, 2026:\n\nCurrent production config has `AUTH_MODE=oauth`, but no Google/X client IDs or secrets have been installed yet. The route contracts exist, and demo/local behavior is documented, but this issue should stay open until provider credentials, callbacks, token exchange, session hardening, and extension handoff are implemented and smoke-tested.\n\nAcceptance criteria reminder:\n- Google OAuth app configured with the Worker callback URL.\n- X OAuth app configured with the Worker callback URL.\n- Provider client IDs/secrets stored through Cloudflare/GitHub secrets, not committed.\n- `GET /api/auth/{provider}/start` redirects to the provider in production.\n- Callback establishes a session and extension token handoff without leaking state or tokens.\n",
+        "createdAt": "2026-05-01T03:20:57Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/24#issuecomment-4357623013",
+        "viewerDidAuthor": true
+      }
+    ],
+    "labels": [
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnYQw",
+        "name": "type:epic",
+        "description": "Parent issue grouping related delivery work",
+        "color": "5319E7"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnZjA",
+        "name": "area:auth",
+        "description": "OAuth, sessions, identity, extension handoff",
+        "color": "F9D0C4"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnaNA",
+        "name": "priority:p0",
+        "description": "Critical path for MVP scaffolding",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnaWg",
+        "name": "learning-log",
+        "description": "Issue must document learning, roadblocks, and pitfalls",
+        "color": "C5DEF5"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcna7A",
+        "name": "risk:security",
+        "description": "Security, auth, session, abuse, or privacy risk",
+        "color": "8B0000"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChc33bg",
+        "name": "bounty:gap",
+        "description": "Gap found against bounty.txt requirements",
+        "color": "B60205"
+      }
+    ],
+    "number": 24,
+    "state": "OPEN",
+    "title": "Epic: Real X/Google auth and extension handoff",
+    "updatedAt": "2026-05-01T03:20:57Z",
+    "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/24"
+  },
+  {
+    "body": "Parent: #21\n\n## Bounty discrepancy\n\nThe bounty asks users to either provide a URL or use the current page, then choose start/end times or a text section. Current UI has the skeleton, but URL publish on web is missing and extension start/end values need to drive the API payload.\n\n## Learning objective\n\nBuild the capture journey so a user can publish a source-linked annotation from either web URL input or current-tab extension context.\n\n## Acceptance criteria\n\n- [ ] Web feed has a compact new annotation composer with URL input, text quote, optional media start/end, and commentary.\n- [ ] Extension timecode inputs are stateful and publish the exact entered range.\n- [ ] Extension rejects ranges over 90 seconds before calling the API.\n- [ ] Text selection from content script remains the default when selected text exists.\n- [ ] Tests cover P50 text publish and P95 over-90-second validation at UI and API boundaries.\n\n## Roadblocks and learning log\n\n- Pitfall: timecode fields can look functional while publish still uses fallback values; tests must assert payload shape.\n- Transfer: this feeds permalink, public feed, and claim evidence quality.\n",
+    "comments": [
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7eAWA",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Progress landed locally:\n- Web feed now has a URL capture composer for source URL, title, text quote or media timecodes, and commentary.\n- Extension side panel timecode inputs are stateful and pass the entered range into the publish payload.\n- Extension blocks media ranges above 90 seconds before publish.\n- Content-script selected text remains the default text capture context.\n\nVerification:\n- `npm run typecheck`\n- `npm test -- --run` now includes composer coverage.\n- `npm run build` builds the web client and extension.\n- API smoke publish with a 60-second media range succeeds; 100-second range returns `invalid_annotation`.\n\nLeaving open for real browser extension verification across representative sites before marking the whole capture journey complete.",
+        "createdAt": "2026-05-01T01:42:24Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/23#issuecomment-4357324888",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7eKkg",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Additional regression coverage added after the first progress note:\n- `apps/extension/src/sidepanel/api.test.ts` verifies exact time ranges are sent in the extension publish payload.\n- It verifies >90-second ranges fail before any fetch call.\n- It verifies recorded audio commentary is uploaded before publish and becomes `commentary.kind=audio`.\n\nLatest verification:\n- `npm run typecheck`\n- `npm test -- --run` -> 4 files, 30 tests passing\n- `npm run test:workers`\n- `npm run build`\n\nKeeping this open only for real unpacked-extension browser verification across representative pages.",
+        "createdAt": "2026-05-01T01:43:20Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/23#issuecomment-4357327506",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7hmaA",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Closure audit, May 1 2026:\n\nThis is mostly closeable without external credentials. Current local evidence shows the web URL composer, selected-text path, extension current-tab context, stateful timecodes, and >90 second rejection are implemented and covered by tests/build.\n\nMinimal work before closing:\n- Run and record an unpacked-extension browser pass against at least one article/text-selection page, one page with a `<video>`, and one page with `<audio>` or podcast media.\n- Verify the built extension can publish against the intended API base for the demo. Today the extension publish helper is hardcoded to `http://localhost:8787`, which is fine for local MVP but not enough for a public bounty demo.\n- Capture the smoke evidence in this issue, including one successful text annotation and one successful media-timecode annotation.\n\nNo OAuth or Cloudflare credentials are needed for the remaining browser verification itself, but a public demo will need the deployment/API-base piece from #22/#28.\n",
+        "createdAt": "2026-05-01T02:01:48Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/23#issuecomment-4357383784",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7onSw",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Progress update for the capture journey:\n\n- Extension publish API is no longer hardcoded to localhost. It now reads/writes the API base URL from `chrome.storage.local` and exposes it in the side panel Settings tab.\n- Local and production review can switch API targets without source edits or rebuilds.\n- Web profile follow action is now wired to the existing `/api/follows/:userId` route instead of local-only UI state.\n- Build/test regression blockers were fixed by pinning away from the Vite 8 Rolldown deadlock and splitting Vitest node/web passes.\n\nVerified locally:\n- `npm run typecheck`\n- `npm test`\n- `npm run test:workers`\n- `npm run build`\n\nStill open before closing #23:\n- Browser-level unpacked extension smoke proof from issue #30.\n- Public deployed API URL once Cloudflare resources/secrets are configured.",
+        "createdAt": "2026-05-01T02:40:18Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/23#issuecomment-4357498699",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7wL6g",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Capture journey status, May 1, 2026:\n\nThe web/API deployment is no longer the blocker: public Pages and Worker URLs are live, and production smoke created a real annotation, comment, and claim notice.\n\nWhat this epic still owns:\n- Connect browser/UI capture state to payload-level evidence for source URL, selected text, media start/end/duration, and commentary.\n- Make the public web client and extension use the same API contract consistently.\n- Add regression tests around the exact payloads users produce, not just fixture rendering.\n- Document p50 vs p95 proof: p50 is a successful publish; p95 is exact quote/timecode preservation, invalid duration rejection, and source-link integrity under realistic browser use.\n",
+        "createdAt": "2026-05-01T03:20:51Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/23#issuecomment-4357622762",
+        "viewerDidAuthor": true
+      }
+    ],
+    "labels": [
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnYQw",
+        "name": "type:epic",
+        "description": "Parent issue grouping related delivery work",
+        "color": "5319E7"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnZOQ",
+        "name": "area:web-client",
+        "description": "Public web app, feed, profile, permalink pages",
+        "color": "C2E0C6"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnZTA",
+        "name": "area:chrome-extension",
+        "description": "MV3 extension, side panel, content scripts",
+        "color": "D4C5F9"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnZ2A",
+        "name": "area:media",
+        "description": "Clip refs, uploads, source metadata, media policy",
+        "color": "FEF2C0"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnaNA",
+        "name": "priority:p0",
+        "description": "Critical path for MVP scaffolding",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnaWg",
+        "name": "learning-log",
+        "description": "Issue must document learning, roadblocks, and pitfalls",
+        "color": "C5DEF5"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChc33bg",
+        "name": "bounty:gap",
+        "description": "Gap found against bounty.txt requirements",
+        "color": "B60205"
+      }
+    ],
+    "number": 23,
+    "state": "OPEN",
+    "title": "Epic: Complete extension and web capture journey",
+    "updatedAt": "2026-05-01T03:20:52Z",
+    "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/23"
+  },
+  {
+    "body": "Parent: #21\n\n## Bounty discrepancy\n\nThe product is not publicly deployed. The latest audit found no GitHub deployments, no configured Cloudflare GitHub secrets/vars, unresolved `annotated-canvas.pages.dev`, and placeholder production D1/KV IDs.\n\n## Learning objective\n\nUse Wrangler and GitHub CLI to make production setup reproducible from the command line instead of relying on dashboard-only steps.\n\n## Prior knowledge\n\n- `apps/api/wrangler.production.jsonc` is the production Worker config.\n- `.github/workflows/ci.yml` already has a gated deploy job.\n- Cloudflare remote setup requires a logged-in Wrangler session or a CI API token/account ID.\n\n## Practice task\n\nCreate and run a CLI bootstrap that can:\n\n- verify Wrangler auth,\n- create/reuse D1, KV, R2, queues, and Pages project resources,\n- patch production config IDs,\n- run remote D1 migrations,\n- deploy Worker and web build,\n- configure GitHub secrets/vars needed by CI/CD.\n\n## Acceptance criteria\n\n- [ ] `npm run cf:setup:production` exists and documents every required command.\n- [ ] Wrangler auth is verified with `npm run cf:whoami`.\n- [ ] Production D1/KV placeholders are replaced with real IDs.\n- [ ] Remote migrations apply against production D1.\n- [ ] Worker deploy returns a public `.workers.dev` URL.\n- [ ] Web client deploy returns a public Pages URL.\n- [ ] GitHub Actions deploy job runs rather than skips on `main`.\n- [ ] Public smoke tests pass for `/api/health`, feed, permalink, and web root.\n\n## Roadblocks and learning log\n\n- Current roadblock: local Wrangler is not authenticated. A human must complete `wrangler login` or provide a scoped token/account ID.\n- Pitfall: do not enable `CLOUDFLARE_DEPLOY_ENABLED` until resource IDs and secrets are configured, or CI will fail during deploy.\n",
+    "comments": [
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7eAJQ",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Implemented the CLI bootstrap path in this branch: `npm run cf:setup:production` and `npm run cf:deploy:production` now drive Wrangler resource setup/deploy from `scripts/cloudflare/setup-production.mjs`.\n\nVerification:\n- `npm run cf:setup:production` prints the production resource plan and current placeholder IDs.\n- It fails cleanly at the real blocker: Wrangler is not authenticated.\n\nCurrent blocker:\n- `wrangler whoami` returns: not authenticated. There are also no `CLOUDFLARE_*` shell env vars, no GitHub repo secrets, and no GitHub repo vars yet.\n\nNext action after human login/token:\n- `npm exec -- wrangler login`\n- `npm run cf:setup:production -- --apply --pages`\n- export `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN`, then `npm run cf:setup:production -- --apply --github`\n- `npm run cf:deploy:production`",
+        "createdAt": "2026-05-01T01:42:23Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/22#issuecomment-4357324837",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7gT3A",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Updated Cloudflare setup for the user's GitHub-first deployment preference.\n\nChanges in this pass:\n- GitHub Actions now supports manual production deploy dispatch on main with a deploy gate.\n-  and  frame GitHub Actions as the production control plane.\n-  can dry-run GitHub deployment wiring without local Wrangler auth.\n-  stores Cloudflare credentials in the GitHub  environment and sets ; secret values are passed via stdin and redacted from command logs.\n\nCurrent blocker remains credentials, not code:\n-  is unset.\n-  is unset.\n- Production D1/KV IDs are still placeholders until Cloudflare resources are created or provided.\n\nVerified:\n- \n> annotated-canvas@0.1.0 cf:setup:production\n> node scripts/cloudflare/setup-production.mjs --github\n\nAnnotated Canvas Cloudflare production bootstrap\nMode: dry run. Add --apply to create resources and patch config.\nPlanned resources:\n- D1: annotated_canvas\n- KV: SESSION_KV\n- R2: annotated-canvas-media\n- Queues: annotated-canvas-jobs, annotated-canvas-dlq\n- Pages project: annotated-canvas\n- GitHub deployment environment: production\nCurrent config IDs: {\"d1Id\":\"REPLACE_WITH_PRODUCTION_D1_DATABASE_ID\",\"kvId\":\"REPLACE_WITH_PRODUCTION_KV_NAMESPACE_ID\"}\nGitHub wiring dry run: set CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN before using --apply --github.\nGitHub deployment wiring complete. No local Wrangler auth needed for this step. now produces a useful GitHub-first dry run without requiring local Wrangler login.",
+        "createdAt": "2026-05-01T01:54:38Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/22#issuecomment-4357362652",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7gdyg",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Corrected GitHub-first Cloudflare setup note.\n\nChanges in this pass:\n- GitHub Actions now supports manual production deploy dispatch on `main` with a deploy gate.\n- `docs/cloudflare-cli.md` and `docs/deployment-devops.md` frame GitHub Actions as the production control plane.\n- `scripts/cloudflare/setup-production.mjs --github` can dry-run GitHub deployment wiring without local Wrangler auth.\n- `--apply --github` stores Cloudflare credentials in the GitHub `production` environment and sets `CLOUDFLARE_DEPLOY_ENABLED=true`; secret values are passed via stdin and redacted from command logs.\n\nCurrent blocker remains credentials, not code:\n- `CLOUDFLARE_ACCOUNT_ID` is unset.\n- `CLOUDFLARE_API_TOKEN` is unset.\n- Production D1/KV IDs are still placeholders until Cloudflare resources are created or provided.\n\nVerified:\n- `npm run cf:setup:production -- --github` now produces a useful GitHub-first dry run without requiring local Wrangler login.\n",
+        "createdAt": "2026-05-01T01:55:30Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/22#issuecomment-4357365194",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7iPEQ",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Cloudflare/GitHub deployment readiness update:\n\nChanges in this pass:\n- `.github/workflows/ci.yml` now deploys both Cloudflare surfaces from GitHub: remote D1 migrations, Worker deploy, web build with `VITE_API_BASE_URL` set to the deployed Worker URL, then Cloudflare Pages deploy for `dist/web`.\n- `scripts/cloudflare/setup-production.mjs` local fallback deploy now parses the Worker URL, passes it into the web build, deploys Pages, and prints both Worker and Pages URLs.\n- `docs/cloudflare-cli.md` and `docs/deployment-devops.md` now document the GitHub-first resource/bootstrap sequence, Pages deploy command, and required Pages token permission.\n\nVerified:\n- `npm run cf:setup:production -- --github` dry-runs without local Wrangler auth and reports placeholder D1/KV IDs.\n- `npm run typecheck`\n- `npm test`\n- `npm run test:workers`\n- `npm run build`\n- workflow YAML parses.\n\nCurrent blocker remains credentials/resources, not repo wiring:\n- `npm run cf:whoami` reports: `You are not authenticated. Please run \\`wrangler login\\`.`\n- No `CLOUDFLARE_*` env vars are set in this shell.\n- `gh variable list` returned no repo variables.\n- `gh secret list --env production` returned no visible production environment secrets.\n- `apps/api/wrangler.production.jsonc` still contains placeholder production D1/KV IDs.\n\nCredential-holder next commands:\n\n```bash\ngh auth status\nexport CLOUDFLARE_ACCOUNT_ID=...\nexport CLOUDFLARE_API_TOKEN=...\nnpm run cf:setup:production -- --apply --resources --pages\ngit diff apps/api/wrangler.production.jsonc\nnpm run cf:setup:production -- --apply --github\n```\n\nThen commit the generated production IDs, merge/push to `main`, and run the deploy from GitHub if a push did not already trigger it:\n\n```bash\ngh workflow run \"CI and Deploy\" --ref main -f deploy_production=true\n```\n",
+        "createdAt": "2026-05-01T02:05:07Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/22#issuecomment-4357394193",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7qKYg",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "## Cloudflare via GitHub reconciliation\n\nChecked the current Cloudflare docs on May 1, 2026:\n\n- Cloudflare Workers Builds now supports native Git integration for GitHub/GitLab Workers deploys.\n- Cloudflare Pages also supports GitHub/GitLab Git integration with previews and status checks.\n- GitHub Actions deployments still require `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` as CI secrets.\n\nDecision for this MVP:\n\nKeep GitHub Actions as the first production control plane because it coordinates the full ordered release path in one gate: typecheck, tests, Worker-runtime tests, build, remote D1 migrations, Worker deploy, web build with the deployed Worker URL, and Pages deploy. Native Cloudflare Git integration can be added later for preview ergonomics, but it should not bypass the migration/smoke sequence.\n\nRepo updates:\n\n- `docs/deployment-devops.md` now documents the Cloudflare native Git integration option and why the first deploy stays GitHub Actions controlled.\n- `docs/cloudflare-cli.md` now mirrors that guidance.\n\nCurrent blocker:\n\n- Playwright dashboard automation hits Cloudflare security verification, so I am not bypassing it.\n- Desktop Chrome is at the GitHub login step for Cloudflare. Human login/2FA/Turnstile is needed before dashboard work can continue.\n- CLI resource setup still needs either local Wrangler auth or a scoped Cloudflare API token.\n",
+        "createdAt": "2026-05-01T02:49:11Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/22#issuecomment-4357524066",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7qsHw",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "## CI after deployment-doc updates\n\nPushed the current MVP/deployment commits to `main`:\n\n- `49ddf78` `feat: verify local extension smoke flow`\n- `256a55f` `docs: prepare Cloudflare deployment packet`\n\nGitHub Actions run `25199948055` passed the verification job:\n\n- typecheck passed\n- unit/integration tests passed\n- Worker runtime tests passed\n- build passed\n\nThe production deploy job skipped as expected because `CLOUDFLARE_DEPLOY_ENABLED` is not set to `true` yet. That gate should stay off until production D1/KV IDs are committed and the GitHub `production` environment has valid Cloudflare secrets.\n",
+        "createdAt": "2026-05-01T02:52:06Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/22#issuecomment-4357532703",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7wJKQ",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Production deployment update, May 1, 2026:\n\nWhat is live now:\n- Worker: https://annotated-canvas-api.jaybhagat841.workers.dev\n- Pages: https://annotated-canvas.pages.dev\n- D1: annotated_canvas / 84bcbb47-3471-4a78-a99d-1f02c19bb2d9\n- KV: SESSION_KV / 46ef271ad63242ea86c3a657f05fa556\n- Queues: annotated-canvas-jobs and annotated-canvas-dlq\n- Pages project: annotated-canvas\n\nRegression and deploy evidence:\n- `npm run typecheck` passed.\n- `npm test` passed.\n- `npm run test:workers` passed.\n- `npm run build` passed, including the Chrome extension artifact.\n- `npm run cf:migrate:production` reports no pending migrations after the production seed migration was applied.\n- `npm run cf:deploy:production` deployed Worker version `3b8e0722-aa50-49a7-86c5-b99869bbd0d0` and Pages deployment `https://45bbbb59.annotated-canvas.pages.dev`.\n- Public smoke verified health, feed, profile, permalink, removed state, comment creation, claim notice creation, and audio upload fallback.\n\nRoadblocks/pitfalls for the learning log:\n- Wrangler KV create emits a JSON id rather than a UUID-shaped value; the setup helper now parses JSON ids.\n- `--deploy --pages` previously tried to reprovision resources because deploy implied apply. The helper now keeps deploy and provisioning separate.\n- R2 creation fails with Cloudflare API code `10042` until R2 is enabled in the account. Production intentionally omits the `MEDIA_BUCKET` binding and returns `status: intent-created` for audio uploads until #26 completes storage.\n- The API originally returned `https://annotated.example` canonical permalinks. The repository now derives `permalink_url` from `APP_ORIGIN`, and the regression test asserts it.\n\nRemaining before this epic closes:\n- Set GitHub `production` environment secrets `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`.\n- Set repository variable `CLOUDFLARE_DEPLOY_ENABLED=true`.\n- Prove deploy-from-main through GitHub Actions, not just local Wrangler OAuth.\n",
+        "createdAt": "2026-05-01T03:20:36Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/22#issuecomment-4357622057",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7wm-w",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Final repository CI update, May 1, 2026:\n\n- Commit `d1f6071` shipped the Cloudflare production config/docs/migration and canonical permalink fix.\n- Commit `ea0755c` upgraded first-party GitHub Actions from `actions/checkout@v4` / `actions/setup-node@v4` to `@v6` after GitHub warned that the v4 actions still run on Node 20.\n- Latest CI run is green: https://github.com/ChaiWithJai/annotated-canvas/actions/runs/25200714666\n- Verify job passed typecheck, unit/integration tests, workerd tests, and build.\n- Deploy job is intentionally skipped because `CLOUDFLARE_DEPLOY_ENABLED` and the production Cloudflare API token are not installed yet.\n\nCurrent close decision: keep this issue open. Local Cloudflare deployment is live and verified, but the issue should close only after deploy-from-main is enabled and proven through GitHub Actions.\n",
+        "createdAt": "2026-05-01T03:23:25Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/22#issuecomment-4357629691",
+        "viewerDidAuthor": true
+      }
+    ],
+    "labels": [
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnYQw",
+        "name": "type:epic",
+        "description": "Parent issue grouping related delivery work",
+        "color": "5319E7"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnY9A",
+        "name": "stream:cloudflare-architecture",
+        "description": "Cloudflare services and architecture stream",
+        "color": "F38020"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnaNA",
+        "name": "priority:p0",
+        "description": "Critical path for MVP scaffolding",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnaWg",
+        "name": "learning-log",
+        "description": "Issue must document learning, roadblocks, and pitfalls",
+        "color": "C5DEF5"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnanA",
+        "name": "risk:platform",
+        "description": "Platform constraint or integration risk",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChc33bg",
+        "name": "bounty:gap",
+        "description": "Gap found against bounty.txt requirements",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChc33ng",
+        "name": "area:deployment",
+        "description": "Deployment, CI/CD, and public production hosting",
+        "color": "0366D6"
+      }
+    ],
+    "number": 22,
+    "state": "OPEN",
+    "title": "Epic: Cloudflare CLI production setup and deployment",
+    "updatedAt": "2026-05-01T03:23:25Z",
+    "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/22"
+  },
+  {
+    "body": "## Bounty source\n\nThis issue tracks the current product against the latest local bounty source in `bounty.txt`.\n\n## Current repo evidence\n\n- Local web app and local Worker API run.\n- CI verify is green.\n- Repo is public.\n- No public Cloudflare deployment is live yet.\n- Chrome extension is buildable as an unpacked MV3 side panel.\n\n## Discrepancy table\n\n| Bounty requirement | Current status | Gap |\n| --- | --- | --- |\n| Sidebar Chrome extension | Partial | MV3 side panel exists, but auth handoff, robust current-tab capture, and full media controls are not complete. |\n| Highlight and clip text/audio/video from any website | Partial | Text selection and media reference scaffolds exist; audio/video capture needs real start/end binding and broader page detection. |\n| Add commentary and annotations | Partial | Text commentary publishes; recorded audio commentary is not implemented end to end. |\n| Save annotations to landing page linking back to source | Partial | Permalink view/API exists; production public URL and final source rendering polish are missing. |\n| Public social feed | Partial | Feed exists; public deployment and real data path are missing. |\n| Follow users and engage | Partial | Follow and engagement primitives exist; comments/discussions are not implemented. |\n| Account via X or Google | Partial | Demo OAuth route exists; real provider token exchange and configured secrets are missing. |\n| User can input URL or use current page | Partial | Current-tab extension context exists; web URL input/publish flow is missing. |\n| Prompt for clip start/end or text section | Partial | UI shows fields, but extension publish currently does not fully bind user-entered start/end. |\n| Max clip size 90 seconds | Implemented | Contract/API reject media clips above 90 seconds. |\n| Downgrade clip to 240p / below 480p | Missing/decision needed | Current architecture stores third-party media as references only; owned uploads need a Cloudflare Stream/processing plan. |\n| Text or recorded audio commentary | Partial | Text works; recorded audio capture/upload/publish is missing. |\n| Users can leave comments | Missing | No comments contract/API/UI yet. |\n| File a claim button | Partial | Claim modal/API exists; status page/events and production delivery are incomplete. |\n| All content links to original source | Implemented for third-party contracts | Zod contract rejects third-party clips without source attribution. |\n| Submit to annotated.lovable.app | Missing | Needs public deployed URL and submission checklist. |\n\n## Child work\n\n- #22 Cloudflare CLI production setup and deployment\n- #23 Complete extension and web capture journey\n- #24 Real X/Google auth and extension handoff\n- #25 Public feed, comments, follows, and engagement parity\n- #26 Audio commentary and 240p media policy\n- #27 Harden claim filing into a reviewable notice workflow\n- #28 Prepare final bounty submission package\n\n## Learning objective\n\nConvert the bounty thread into executable delivery criteria so every new issue teaches a contributor exactly what must change and why.\n\n## Acceptance criteria\n\n- [ ] Every gap above is represented by a child implementation issue or an explicit product decision.\n- [ ] Child issues include bounty-specific acceptance criteria and regression evidence.\n- [ ] Public deployment issue records the Cloudflare CLI commands, resource IDs needed, and current authentication blocker.\n- [ ] This issue closes only when the deployed product can be submitted for the bounty.\n\n## Roadblocks and learning log\n\n- Roadblock: Cloudflare CLI is installed but not authenticated; `wrangler whoami` currently requires login.\n- Decision: third-party media should remain source-linked by default; 240p handling must be clarified as embed/transform for owned media versus third-party references.\n",
+    "comments": [
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7eaeA",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Bounty gap pass pushed in commit `1963955`.\n\nFiled child issues:\n- #22 Cloudflare CLI production setup and deployment\n- #23 Complete extension and web capture journey\n- #24 Real X/Google auth and extension handoff\n- #25 Public feed/comments/follows/engagement parity — closed locally\n- #26 Audio commentary and 240p media policy\n- #27 Claim filing review workflow — closed locally\n- #28 Final bounty submission package\n\nRepo artifact added: `docs/bounty-gap-audit.md`.\n\nLatest verification:\n- Local `npm run typecheck`\n- Local `npm test -- --run` -> 4 files, 30 tests passing\n- Local `npm run test:workers`\n- Local `npm run build`\n- GitHub Actions run 25198282018 is green for verify; deploy job skipped because Cloudflare deploy is intentionally gated and auth/secrets are not configured.\n\nCurrent blocker for full bounty readiness remains production deployment/auth: Wrangler is not authenticated locally and GitHub has no Cloudflare secrets or deploy variable yet.",
+        "createdAt": "2026-05-01T01:44:44Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/21#issuecomment-4357331576",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7hktA",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Closure audit, May 1 2026:\n\nInspected #23, #24, #26, #28 plus the current web app, Worker API, and MV3 extension. Local verification still passes:\n- `npm run typecheck`\n- `npm test` -> 4 files, 30 tests passing\n- `npm run test:workers` -> 1 file, 1 test passing\n- `npm run build`\n\nCurrent closure map:\n- Closeable without external credentials: #23 after real unpacked-extension browser verification and production API-base handling; most web/extension capture, source attribution, timecode, comments, claims, and feed behavior exists locally.\n- Keep open for product/code work: #24 auth/session/extension-token hardening; #26 audio asset finalization and 240p owned-media policy; #28 submission package.\n- Blocked by external credentials/resources: Cloudflare production D1/KV/R2/Queues/Pages IDs and deploy token/account, Google/X OAuth apps and secrets, and Cloudflare Stream/owned-video settings if the owned-upload path is required.\n\nAdditional local audit note: the web profile follow button currently toggles local React state only while the API follow route exists, so follow parity is not fully proven from the UI yet. Production deployment is still blocked: `apps/api/wrangler.production.jsonc` has placeholder D1/KV IDs, repo/environment secret and variable lists are empty, `wrangler whoami` reports not authenticated, and the latest CI verify run is green while production deploy is skipped.\n",
+        "createdAt": "2026-05-01T02:01:39Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/21#issuecomment-4357383348",
+        "viewerDidAuthor": true
+      },
+      {
+        "id": "IC_kwDOSRRxuc8AAAABA7wJKg",
+        "author": {
+          "login": "ChaiWithJai"
+        },
+        "authorAssociation": "OWNER",
+        "body": "Bounty readiness audit update, May 1, 2026:\n\nCloseable/complete areas:\n- Public deployment is live on Cloudflare Pages and Workers.\n- Public feed/profile/permalink/removed routes return `200`.\n- Public comments and claim notice intake are smoke-tested.\n- Max 90-second media validation remains covered by regression tests.\n- Canonical API permalinks now reconcile to the public Pages hostname.\n\nStill open against `bounty.txt`:\n- #23: exact UI-to-payload proof for selected text, current page, and media timecode capture.\n- #24: real X/Google OAuth credentials and callback exchange.\n- #26: recorded audio commentary storage and 240p/sub-480p owned-media policy.\n- #30: local Chrome extension p95 smoke proof beyond the current unpacked side-panel/current-page proof.\n- #22: CI/CD deploy-from-main through GitHub Actions after a scoped Cloudflare API token is installed.\n\nProfessional release stance: we have a live MVP, but not a fully closed bounty implementation. The submission should state the p50 product surfaces that work and explicitly name the p95 gaps instead of overclaiming.\n",
+        "createdAt": "2026-05-01T03:20:36Z",
+        "includesCreatedEdit": false,
+        "isMinimized": false,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/21#issuecomment-4357622058",
+        "viewerDidAuthor": true
+      }
+    ],
+    "labels": [
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnYQw",
+        "name": "type:epic",
+        "description": "Parent issue grouping related delivery work",
+        "color": "5319E7"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnaNA",
+        "name": "priority:p0",
+        "description": "Critical path for MVP scaffolding",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChcnaWg",
+        "name": "learning-log",
+        "description": "Issue must document learning, roadblocks, and pitfalls",
+        "color": "C5DEF5"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChc33bg",
+        "name": "bounty:gap",
+        "description": "Gap found against bounty.txt requirements",
+        "color": "B60205"
+      },
+      {
+        "id": "LA_kwDOSRRxuc8AAAAChc34KQ",
+        "name": "area:bounty-submission",
+        "description": "Submission readiness for the Annotated bounty",
+        "color": "FBCA04"
+      }
+    ],
+    "number": 21,
+    "state": "OPEN",
+    "title": "Epic: Bounty gap audit and submission readiness",
+    "updatedAt": "2026-05-01T03:20:36Z",
+    "url": "https://github.com/ChaiWithJai/annotated-canvas/issues/21"
+  }
+]


### PR DESCRIPTION
## Summary
- replaces inert web sign-in affordances with network-backed Google/X auth start actions and visible signed-in/signed-out state
- hardens oauth-mode API behavior so missing provider config/session KV fails closed instead of falling back to fake callbacks
- validates oauth state/code, rejects replay, requires sessions for `/api/me` and extension-token, deletes sessions on logout, adds credentialed CORS/cookie handling, and sanitizes `return_to`
- adds gas-town issue planning artifacts plus extension/dependency gate docs for #23/#30/#22/#26

## Verification
- `npm run typecheck`
- `npm test`
- `npm run test:workers`
- `npm run build`
- local Chrome render check at `http://127.0.0.1:5173/home`

## Still Open
- real Google/X token exchange and user profile persistence are not faked; #24 still requires provider apps/secrets and adapter implementation
- #30 still needs browser evidence against the production Worker URL
- #22 still needs Cloudflare API token/secret wiring for deploy-from-main
- #26 still needs R2 or alternate durable audio storage plus 240p owned-media policy

Refs #24, #23, #30, #22, #26.
