### PR TITLE
docs: reconcile bounty submission readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The product is based on the `Annotated` bounty context captured in this reposito
 - `docs/cloudflare-cli.md` defines Cloudflare CLI setup and resource commands.
 - `docs/testing-strategy.md` defines the testing trophy strategy with P50/P95 coverage.
 - `docs/issue-learning-loop.md` defines how issues should document learning, pitfalls, and roadblocks.
+- `docs/bounty-gap-audit.md` and `docs/submission-packet.md` define the current bounty readiness packet, including live URLs, known limitations, and open issue gates.
 
 ## Local Development
 

--- a/docs/bounty-gap-audit.md
+++ b/docs/bounty-gap-audit.md
@@ -2,39 +2,156 @@
 
 Source: `bounty.txt`, captured from the April 30, 2026 Annotated bounty thread.
 
-## Current Status
+This audit is intentionally reviewer-facing: it separates what works now from what is deployed with limitations, what is blocked by human-owned credentials or platform switches, and what is not yet implemented. It should be read together with `docs/submission-packet.md`.
+
+## Status Legend
+
+- **Working now**: implemented and backed by local or production evidence.
+- **Deployed but limited**: public URL exists, but the feature is demo/fallback/partial and must not be presented as complete.
+- **Blocked by human credentials/secrets**: repo work can continue, but final proof needs external account setup, secrets, or platform enablement.
+- **Not yet implemented**: missing product/code/policy work remains.
+
+## Current State
 
 - The repository is public: `https://github.com/ChaiWithJai/annotated-canvas`.
-- The local web client and local Worker API run.
-- CI verifies typecheck, tests, Worker runtime tests, and production builds.
-- The product is not deployed to a public Cloudflare URL yet.
-- The Chrome extension can be built, loaded unpacked locally, opened as a side panel, and used to publish a current-page annotation into the local API.
-- A reviewer-facing submission packet exists at `docs/submission-packet.md` with live URL placeholders.
+- Production is live through local Wrangler deployment:
+  - Web: `https://annotated-canvas.pages.dev`
+  - API health: `https://annotated-canvas-api.jaybhagat841.workers.dev/api/health`
+- GitHub Actions verification is green after PR #31, but deploy-from-main is still gated off because Cloudflare GitHub secrets and `CLOUDFLARE_DEPLOY_ENABLED=true` are not installed.
+- The Chrome extension builds to `dist/extension`, loads unpacked locally, opens as an MV3 side panel, saves an API base URL, and has local current-tab publish evidence.
+- PR #31 fixed the inert sign-in UI and deployed the safer production state: Google/X buttons now surface `auth_not_configured` instead of doing nothing or minting fake production sessions.
+- Real OAuth provider exchange, production extension p95 smoke, durable recorded-audio storage, and owned-media 240p policy remain open.
 
-## Discrepancies
+## Bounty Requirement Matrix
 
-| Bounty requirement | Current status | Delivery issue |
-| --- | --- | --- |
-| Sidebar Chrome extension | Local proof: MV3 side panel loads from `dist/extension` and publishes to the local API. | #30 |
-| Highlight and clip media from any website | Partial: current tab, selection, and media references exist; broad compatibility needs hardening. | #23 |
-| Add commentary and annotations | Partial: text works; audio recording path is new and still needs production media hardening. | #26 |
-| Landing page linking back to original source | Partial: permalink exists locally; public deployment missing. | #22, #28 |
-| Public social feed | Partial: feed exists locally; public deployment missing. | #22, #25 |
-| Follow and engage with annotations | Partial: follows and engagement exist; comments were missing and are now tracked in #25. | #25 |
-| Account via X or Google | Partial: demo OAuth exists; real provider exchange and secrets are missing. | #24 |
-| URL input or current page | Partial: current-page extension publish works locally; web composer covers URL input locally. | #23, #30 |
-| Prompt for start/end or text section | Partial: UI exists; issue #23 tracks binding and regression proof. | #23 |
-| Max clip size 90 seconds | Implemented in contracts/API. | #21 |
-| Downgrade to 240p / below 480p | Missing product decision for third-party references versus owned uploads. | #26 |
-| Text or recorded audio commentary | Partial: text works; recorded audio needs full upload/finalize proof. | #26 |
-| Users can leave comments | Implemented locally in API/UI during this audit pass. | #25 |
-| File a claim | Partial: notice intake works; status/events are now implemented locally and need public proof. | #27 |
-| All content links to original source | Implemented for third-party clips through contracts/API. | #21 |
-| Submit to annotated.lovable.app | Packet drafted; blocked on public deployment URLs and final smoke proof. | #28 |
+| Bounty requirement | Status bucket | Current evidence | Remaining gap | Delivery issue |
+| --- | --- | --- | --- | --- |
+| Sidebar Chrome extension | Working now | `dist/extension` loads unpacked; side panel opens; local publish proof in #30. | Production API-base publish and p95 capture evidence. | #30, #23 |
+| Highlight and clip media from any website | Deployed but limited | Current-tab URL/title, selected-text path, and media time-range controls exist. | Exact selected text and real media `currentTime` must be proven against production payloads. | #23, #30 |
+| Add commentary and annotations | Deployed but limited | Text commentary publishes; public annotation/comment/claim smoke exists. | Recorded audio commentary is not durably stored in production. | #26 |
+| Landing page linking back to original source | Working now | Public permalink exists and API returns canonical Pages `permalink_url`. | Continue to verify every created annotation carries `source_url`. | #21, #28 |
+| Public social feed | Working now | Public feed and profile routes return `200`; production annotation/comment smoke exists. | Final packet should use fresh proof immediately before external submission. | #28 |
+| Follow and engage with annotations | Working now | Comments and engagement paths are implemented; follow UI was wired to API before PR #31 merge. | Include follow/comment proof in final demo, not only local tests. | #23, closed #25 |
+| Account via X or Google | Blocked by human credentials/secrets | Production now fails closed with visible not-configured messages when provider secrets are absent. | Google/X apps, client secrets, token exchange, user/session creation, extension handoff. | #24 |
+| URL input or current page | Deployed but limited | Web URL composer and extension current-page capture exist. | Production extension publish and exact payload evidence still required. | #23, #30 |
+| Prompt for start/end or text section | Deployed but limited | UI/API support text quote and media start/end; API rejects invalid duration. | Browser proof must show user-entered values are the values sent and stored. | #23, #30 |
+| Max clip size 90 seconds | Working now | Contract/API tests reject media over 90 seconds; browser plan records client-side proof requirement. | p95 proof that extension blocks before production network request. | #30 |
+| Downgrade clip to 240p / below 480p | Not yet implemented | Current MVP keeps third-party media source-linked by reference and avoids copying third-party bytes. | Human product/legal decision and owned-upload processing rule are required. | #26 |
+| Text or recorded audio commentary | Deployed but limited | Text works; audio upload endpoint returns an intent when R2 is unavailable. | R2 or alternate storage, finalize semantics, permalink playback/loading proof. | #26 |
+| Users can leave comments | Working now | Public smoke created `cmt_73c82db2-d4db-4661-b92e-84b12b4e74e7`. | Re-run before final submission if the seed data changes. | closed #25, #28 |
+| File a claim | Working now | Public smoke created `claim_36899790-f89f-4add-9744-046b5b46c3f3` and annotation remained public. | Final demo should explain claim is notice intake, not automatic takedown. | closed #27, #28 |
+| All content links to original source | Working now | Third-party clip contracts require `source_url`; permalink shows original source link. | Keep this invariant in extension p95 evidence. | #21, #23 |
+| Submit to annotated.lovable.app | Deployed but limited | Reviewer packet has live URLs, demo script, and honest blocker list. | Human decision to submit with disclosed gaps or wait for #22/#24/#26/#30. | #28 |
 
-## Learning Notes
+## Issue Acceptance Criteria
 
-- A UI field is not proof of behavior. The extension timecode fields must be tied to the publish payload and tested at the contract boundary.
-- Browser proof belongs in the issue thread, not only in a static checklist. #30 now records the Chrome extension ID, side panel behavior, Settings save, local publish, and API feed result.
-- Third-party media should remain source-linked unless a rights-safe owned-upload path is used.
-- Cloudflare setup is blocked by authentication and generated resource IDs, so the durable fix is a repeatable CLI bootstrap plus a clear human login/token step.
+### #21 Bounty Gap Audit And Submission Readiness
+
+- [ ] Gap audit and submission packet use the same status buckets.
+- [ ] Every open bounty gap links to a child issue or explicit product decision.
+- [ ] Final submission language distinguishes live MVP evidence from unfinished bounty-critical criteria.
+- [ ] Close only after #22/#23/#24/#26/#28/#30 are completed or deliberately disclosed by the submitter.
+
+Learning notes:
+
+- **Developer/user must understand**: a live MVP is not the same thing as a complete bounty claim.
+- **Pitfall**: marking a feature complete because a route or button exists, without payload-level proof.
+- **p50 test**: reviewer can load public web/API URLs and follow the demo script.
+- **p95 test**: every bounty-critical limitation is either closed with evidence or called out in the submission text.
+
+### #22 Cloudflare CLI Production Setup And Deployment
+
+- [ ] Production resources and smoke evidence remain documented.
+- [ ] GitHub `production` environment has `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`.
+- [ ] Repository variable `CLOUDFLARE_DEPLOY_ENABLED=true` is set only after secrets are ready.
+- [ ] GitHub Actions deploy-from-main runs instead of skipping and post-deploy smoke passes.
+
+Learning notes:
+
+- **Developer/user must understand**: local Wrangler deployment proves the app can run; GitHub deploy-from-main proves repeatable release control.
+- **Pitfall**: enabling the deploy gate before production IDs/secrets are installed.
+- **p50 test**: `GET /api/health`, web root, feed, profile, permalink, comment, and claim work after local deploy.
+- **p95 test**: the same smoke passes from the commit deployed by GitHub Actions.
+
+### #23 Complete Extension And Web Capture Journey
+
+- [ ] Web URL capture and extension current-page capture both produce valid annotation payloads.
+- [ ] Selected text is preserved from browser selection to side panel, request payload, and stored annotation.
+- [ ] Media start/end/duration are preserved from real page state to payload and stored annotation.
+- [ ] API/source-link invariants are tested at contract and browser boundaries.
+
+Learning notes:
+
+- **Developer/user must understand**: the feature is the exact captured evidence, not just a form with fields.
+- **Pitfall**: timecode fields can display one value while publish sends a fallback.
+- **p50 test**: one normal annotation publishes successfully from web or extension.
+- **p95 test**: exact quote, exact media seconds, invalid duration rejection, and source URL are reconciled across UI, network, and API result.
+
+### #24 Real X/Google Auth And Extension Handoff
+
+- [ ] Google and X client IDs/secrets are installed outside the repo.
+- [ ] Provider callbacks exchange codes for tokens and create/load users.
+- [ ] Production sessions use secure cookies and KV/D1-backed lookup.
+- [ ] Extension token handoff requires an authenticated web session.
+- [ ] Tests cover missing provider config, invalid state, replayed state, logout, and anonymous extension-token rejection.
+
+Learning notes:
+
+- **Developer/user must understand**: the current production state is honest failure, not account creation.
+- **Pitfall**: demo OAuth or fake sessions must never run in production OAuth mode.
+- **p50 test**: unauthenticated user sees a clear sign-in state and provider start route behavior.
+- **p95 test**: invalid/replayed state fails, logout invalidates session, and extension-token cannot be minted anonymously.
+
+### #26 Audio Commentary And 240p Media Policy
+
+- [ ] Recorded audio has durable storage or an approved alternate path.
+- [ ] Upload/finalize metadata prevents arbitrary asset IDs from being published as audio commentary.
+- [ ] Production permalink can load or reference recorded audio commentary.
+- [ ] Third-party clips remain source-linked by reference unless an explicit rights-safe owned-upload path is approved.
+- [ ] Owned-video 240p/sub-480p enforcement is implemented or explicitly excluded from the submission.
+
+Learning notes:
+
+- **Developer/user must understand**: source-linked third-party timestamps are safer than copying media bytes.
+- **Pitfall**: claiming 240p compliance for third-party references when no owned media is transcoded.
+- **p50 test**: text commentary and audio upload intent behavior are clear.
+- **p95 test**: oversized/unsupported audio is rejected, finalized audio persists, and owned-video rendition policy is enforceable.
+
+### #28 Final Bounty Submission Package
+
+- [ ] Public URLs, demo routes, extension install steps, and smoke IDs are current.
+- [ ] Demo script covers sign-in state, URL/current-page capture, text/media commentary, feed, follow/comment, claim filing, and source links.
+- [ ] Known limitations are copied into the external submission.
+- [ ] Human submitter approves whether to post with disclosed gaps or wait.
+
+Learning notes:
+
+- **Developer/user must understand**: the packet is a reviewer script plus a truth-in-advertising checklist.
+- **Pitfall**: hiding OAuth/audio/240p/extension p95 gaps inside implementation detail.
+- **p50 test**: reviewer can run the demo without reading the code.
+- **p95 test**: reviewer can reproduce the highest-risk claims using issue-linked evidence.
+
+### #30 Local Chrome Extension Install And Bounty Smoke Verification
+
+- [ ] Rebuilt `dist/extension` loads unpacked after PR #31.
+- [ ] Settings saves production Worker API base without source edits.
+- [ ] Production publish from a real tab creates an annotation visible through API/feed/permalink.
+- [ ] Selected-text context menu proof preserves the exact quote.
+- [ ] Real video/audio proof preserves exact start/end/duration.
+- [ ] >90-second range is blocked in the browser before any production publish request.
+- [ ] Audio/microphone behavior is tested or explicitly tied back to #26.
+
+Learning notes:
+
+- **Developer/user must understand**: unpacked extension proof is browser-specific and cannot be replaced by normal web tests.
+- **Pitfall**: loading the source extension folder instead of `dist/extension`, or forgetting to reload after rebuild.
+- **p50 test**: side panel opens, saves API base, captures current tab, publishes one annotation.
+- **p95 test**: context menu selection, media current time, network suppression on invalid duration, and audio fallback are evidenced.
+
+## Remaining Blockers
+
+- **#22**: GitHub deploy-from-main needs Cloudflare account ID/API token and the deploy gate enabled.
+- **#24**: Google/X OAuth needs provider apps, secrets, token exchange, user/session persistence, and extension handoff proof.
+- **#26**: R2 is not enabled, audio storage is fallback-only, and owned-media 240p policy is undecided.
+- **#30/#23**: production extension p95 smoke evidence is not yet recorded.
+- **#28**: external submission should wait for these gates or explicitly disclose them.

--- a/docs/dont-make-me-think-audit.md
+++ b/docs/dont-make-me-think-audit.md
@@ -12,6 +12,7 @@ This audit turns the book's principles into product guardrails for Annotated Can
 - Legal and infrastructure language should not leak into user screens.
 - Empty and error states should tell users how to recover.
 - Dense screens should scan as groups: source, clip, note, actions.
+- Reviewer docs should not make readers infer readiness from implementation detail. Use explicit buckets: working now, deployed but limited, blocked by credentials/secrets, and not yet implemented.
 
 ## Surface Audit
 
@@ -29,9 +30,11 @@ This audit turns the book's principles into product guardrails for Annotated Can
 | Extension capture | `Capture type`, `Timecode`, `Text`, and `Commentary` required domain knowledge. | Labels now say `What are you saving?`, `Time range`, `Selected text`, and `Your note`. |
 | Extension footer | `Connect accounts for sync` and `Publish to Canvas` were vague. | Footer now says `Signed out` and `Publish annotation`. |
 | Cloudflare setup docs | Docs still led with local Wrangler login despite the user's GitHub-first deployment preference. | Cloudflare docs now frame GitHub Actions as the production deploy control plane and Wrangler as local/resource/fallback tooling. |
+| Bounty submission docs | Readiness was split across issue comments and a long packet, making reviewers infer what was complete. | `docs/bounty-gap-audit.md` and `docs/submission-packet.md` now use explicit status buckets and issue-linked p50/p95 proof requirements. |
 
 ## Follow-Up Checks
 
 - Verify the extension copy in an unpacked Chrome side panel after browser auth is wired.
 - Revisit the claim modal when real moderation states exist.
 - Re-run a screen-reader pass after the source-pill label change.
+- Before external submission, read only the status bucket and acceptance tables first; if a reviewer cannot classify a requirement in under a few seconds, the packet needs another pass.

--- a/docs/submission-packet.md
+++ b/docs/submission-packet.md
@@ -2,6 +2,17 @@
 
 Reviewer-facing packet for the Annotated MVP bounty described in `bounty.txt`.
 
+## Reviewer Stance
+
+This packet should be submitted as an honest live-MVP packet, not as a claim that every bounty criterion is fully closed. The canonical gap audit is `docs/bounty-gap-audit.md`.
+
+Status buckets used below:
+
+- **Working now**: implemented and backed by local or production evidence.
+- **Deployed but limited**: public URL exists, but the feature is demo/fallback/partial.
+- **Blocked by human credentials/secrets**: external account setup or secrets are required before final proof.
+- **Not yet implemented**: product/code/policy work remains.
+
 ## Submission Links
 
 Fill these in immediately before posting to `https://annotated.lovable.app`.
@@ -151,22 +162,36 @@ curl -X POST http://localhost:8787/api/claims \
 
 | Bounty item | Reviewer evidence | Current status |
 | --- | --- | --- |
-| Sidebar Chrome extension | MV3 side panel loaded from `dist/extension`; side panel opens on source pages. | Local Chrome proof recorded in #30; broader capture hardening remains in #23. |
-| Highlight and clip text/audio/video from any website | Current-tab context, selected text, and media time-range UI/API payloads. | Partial, tracked by #23 and #26. |
-| Add commentary and annotations | Text commentary publish path and API contract. | Partial, audio commentary tracked by #26. |
-| Landing page links back to original source | Annotation permalink includes source metadata and original source link. | Public permalink smoke proof exists. |
-| Public social feed | Feed route and API feed path. | Public Worker and Pages smoke proof exists. |
-| Users can follow and engage | Feed/profile engagement and comments work from the local MVP stream. | Comments work from closed #25; broader parity remains part of review proof. |
-| Account via X or Google | `/api/auth/google/start` and `/api/auth/x/start` demo mode; production OAuth plan. | Partial, real provider exchange blocked by #24 and external secrets. |
-| User can enter URL or use current page | Web URL flow and extension current-page capture surface. | Partial, tracked by #23 for regression-proof binding. |
-| Prompt for start/end or text section | Extension capture controls and API validation for media duration. | Partial, #23 tracks exact UI-to-payload verification. |
-| Max clip size 90 seconds | Contracts/API reject over-90-second media references. | Implemented locally. |
-| Downgrade clip to 240p or below 480p | Product decision: third-party media is source-linked by reference; owned uploads need processing policy. | Blocked by #26. |
-| Text or recorded audio commentary | Text commentary works; upload/commentary contract exists. | Audio recording/finalize blocked by #26. |
-| Users can leave comments | Comment resources and claim/feed docs reflect local completion. | Public smoke created `cmt_73c82db2-d4db-4661-b92e-84b12b4e74e7`. |
-| File a claim button | Claim button/modal and `POST /api/claims` notice intake. | Public smoke created `claim_36899790-f89f-4add-9744-046b5b46c3f3` and annotation remained public. |
-| All content links to original source | `source_url` required for third-party clips. | Implemented for third-party contracts/API. |
-| Submit to annotated.lovable.app | Packet, URLs, demo script, and checklist. | Packet has live URLs; external submission still needs final extension p95 proof and known-limitations disclosure. |
+| Sidebar Chrome extension | MV3 side panel loaded from `dist/extension`; side panel opens on source pages. | **Working now** locally; production p50/p95 proof remains #30/#23. |
+| Highlight and clip text/audio/video from any website | Current-tab context, selected text, and media time-range UI/API payloads. | **Deployed but limited**; exact selected-text and real media-time proof remain #23/#30. |
+| Add commentary and annotations | Text commentary publish path and API contract. | **Deployed but limited**; recorded audio is fallback-only until #26. |
+| Landing page links back to original source | Annotation permalink includes source metadata and original source link. | **Working now** with public permalink smoke. |
+| Public social feed | Feed route and API feed path. | **Working now** with public Worker and Pages smoke. |
+| Users can follow and engage | Feed/profile engagement, follow route, comments, and counts. | **Working now**; include fresh follow/comment proof in final demo. |
+| Account via X or Google | Sign-in buttons call the API and production fails closed when secrets are absent. | **Blocked by human credentials/secrets**; real provider exchange remains #24. |
+| User can enter URL or use current page | Web URL flow and extension current-page capture surface. | **Deployed but limited**; production extension payload proof remains #23/#30. |
+| Prompt for start/end or text section | Extension capture controls and API validation for media duration. | **Deployed but limited**; exact UI-to-payload verification remains #23/#30. |
+| Max clip size 90 seconds | Contracts/API reject over-90-second media references. | **Working now** at contract/API; browser no-network proof remains #30. |
+| Downgrade clip to 240p or below 480p | Third-party media is source-linked by reference; owned uploads need processing policy. | **Not yet implemented**; product/legal decision remains #26. |
+| Text or recorded audio commentary | Text commentary works; audio upload endpoint returns an intent without R2. | **Deployed but limited**; durable audio storage/finalize remains #26. |
+| Users can leave comments | Comment resources and claim/feed docs reflect local completion. | **Working now**; public smoke created `cmt_73c82db2-d4db-4661-b92e-84b12b4e74e7`. |
+| File a claim button | Claim button/modal and `POST /api/claims` notice intake. | **Working now**; public smoke created `claim_36899790-f89f-4add-9744-046b5b46c3f3` and annotation remained public. |
+| All content links to original source | `source_url` required for third-party clips. | **Working now** for third-party contracts/API. |
+| Submit to annotated.lovable.app | Packet, URLs, demo script, and checklist. | **Deployed but limited**; external submission needs final disclosure or completion of open gates. |
+
+## Open-Issue Acceptance Notes
+
+These notes are the reviewer handoff for the seven open tickets. The longer form lives in `docs/bounty-gap-audit.md`.
+
+| Issue | Close only when | Learning note | p50 evidence | p95 evidence |
+| --- | --- | --- | --- | --- |
+| #21 Bounty readiness | The status buckets are current and every gap is closed or explicitly disclosed. | A live MVP is not a complete bounty claim. | Public URLs and demo script work. | No bounty-critical limitation is hidden. |
+| #22 Cloudflare deployment | GitHub Actions deploy-from-main runs and public smoke passes from that commit. | Local Wrangler proves capability; CI deploy proves repeatability. | Local-deployed web/API smoke works. | GitHub-deployed smoke works after secrets are installed. |
+| #23 Capture journey | Web URL/current-page, selected text, and media time payloads reconcile with stored annotations. | Functional fields are not proof unless payloads match user intent. | One normal annotation publishes. | Exact quote/timecode/source integrity are proven. |
+| #24 OAuth | Google/X provider exchange, sessions, and extension handoff work with real credentials. | Honest not-configured failure is safer than fake account creation. | Signed-out and provider-start behavior is visible. | Invalid/replayed state, logout, and anonymous extension-token rejection are tested. |
+| #26 Audio/240p | Recorded audio persists and owned-media 240p/sub-480p policy is implemented or explicitly excluded. | Third-party references and owned media processing are different rights surfaces. | Text commentary and audio intent behavior are clear. | Stored audio, upload validation, and owned-video rendition policy are enforceable. |
+| #28 Submission package | The external post uses current URLs, smoke IDs, and known limitations. | The packet is a reviewer script plus truth-in-advertising checklist. | Reviewer can run the demo without reading code. | Reviewer can reproduce highest-risk claims from linked evidence. |
+| #30 Extension smoke | Production extension p50 and p95 browser evidence is recorded. | MV3 side-panel proof must happen in Chrome, not only in unit tests. | Side panel saves API base and publishes one annotation. | Selected text, media current time, over-90 no-network rejection, and audio fallback are evidenced. |
 
 ## Current Open GitHub Issues
 
@@ -221,6 +246,10 @@ Production smoke evidence recorded on May 1, 2026:
 - Audio commentary recording/finalize and 240p owned-media policy remain unresolved. Tracked by #26.
 - R2 is not enabled in the Cloudflare account yet. Production omits the R2 binding, so audio upload storage remains blocked by #26.
 - Chrome Web Store distribution is not part of the local MVP; reviewers load `dist/extension` unpacked.
+
+Submission language to use if posting before all blockers close:
+
+> Annotated Canvas is live as a source-linked MVP with public feed, permalinks, comments, claim filing, text commentary, and local unpacked Chrome side-panel proof. The remaining disclosed gaps are real Google/X OAuth credentials and token exchange, production extension p95 proof for exact selected text/media timing, durable recorded-audio storage, owned-media 240p processing policy, and GitHub Actions deploy-from-main wiring.
 
 Dependency gate map: `output/reports/gas-town/dependency-gate-map.md`.
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -10,6 +10,7 @@ P50 features are the normal paths most users hit:
 - Extension side panel has timecode and commentary controls.
 - Text or media annotation publishes with an idempotency key.
 - Claim button opens a notice form.
+- Sign-in controls show the correct signed-out or not-configured state.
 
 P95 features are edge paths that decide whether the system is trustworthy:
 
@@ -19,6 +20,21 @@ P95 features are edge paths that decide whether the system is trustworthy:
 - Claim filing does not automatically remove content.
 - Queue consumers can see duplicate jobs and remain idempotent.
 - Extension state survives MV3 service-worker sleep.
+- OAuth state cannot be replayed and demo auth cannot mint fake production sessions.
+- Selected text and media timecodes are preserved exactly from browser UI to stored annotation.
+- Audio commentary cannot publish arbitrary or unfinalized asset IDs.
+
+## Bounty Readiness Test Matrix
+
+| Area | p50 proof | p95 proof | Current owner |
+| --- | --- | --- | --- |
+| Public web/API | Public web, feed, profile, permalink, health, comment, and claim routes return expected results. | The same smoke runs after GitHub Actions deploy-from-main from `main`. | #22, #28 |
+| Extension capture | Unpacked side panel saves API base and publishes one <=90-second annotation. | Selected-text context menu, real media `currentTime`, and >90-second no-network rejection are recorded in Chrome. | #23, #30 |
+| Auth | Signed-out UI and provider start routes fail clearly when secrets are missing. | Real Google/X callbacks exchange tokens, create sessions, reject invalid/replayed state, and gate extension-token minting. | #24 |
+| Source attribution | Annotation permalink displays the source link and API requires `source_url`. | Every p95 extension publish proves the same source URL in UI, network payload, stored annotation, and permalink. | #21, #23 |
+| Commentary | Text commentary publishes and renders. | Recorded audio persists through storage/finalize and permalink loading, or the limitation is disclosed. | #26 |
+| Media policy | Third-party media references keep original source URL plus start/end. | Owned-video upload policy enforces 240p/sub-480p or is explicitly excluded from the submission. | #26 |
+| Claims/comments | Comment and claim POST flows work and claim does not auto-remove content. | Duplicate/retry behavior remains idempotent and moderation state is auditable. | #28 |
 
 ## Trophy Layers
 

--- a/output/reports/gas-town/submission-issue-comment-drafts.md
+++ b/output/reports/gas-town/submission-issue-comment-drafts.md
@@ -1,0 +1,73 @@
+# Submission Issue Comment Drafts
+
+Prepared May 1, 2026 for the seven currently open bounty-readiness issues. These are drafts, not posted comments. They are intentionally concise because the issue threads already contain detailed evidence.
+
+## #21 Bounty Gap Audit And Submission Readiness
+
+```md
+Submission packet reconciliation update:
+
+`docs/bounty-gap-audit.md` and `docs/submission-packet.md` now use the same readiness buckets: working now, deployed but limited, blocked by human credentials/secrets, and not yet implemented.
+
+Close gate remains: keep #21 open until #22/#23/#24/#26/#28/#30 are either completed with evidence or explicitly accepted as disclosed limitations by the human submitter. The packet should not claim full bounty completion while real OAuth, production extension p95 proof, durable audio storage, owned-media 240p policy, and GitHub deploy-from-main are still open.
+```
+
+## #22 Cloudflare CLI Production Setup And Deployment
+
+```md
+Submission packet reconciliation update:
+
+The docs now distinguish local Wrangler production proof from GitHub deploy-from-main proof. Current status is "working live, CI/CD limited": Worker/Pages/D1/KV/Queues are live and smoke-tested, but #22 should close only after `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, and `CLOUDFLARE_DEPLOY_ENABLED=true` are installed and the GitHub Actions deploy job runs instead of skipping.
+
+p50 proof: public web/API smoke works. p95 proof: the same smoke passes from the commit deployed by GitHub Actions.
+```
+
+## #23 Complete Extension And Web Capture Journey
+
+```md
+Submission packet reconciliation update:
+
+The current capture journey is documented as deployed but limited. Web URL capture and extension current-page capture exist, but close requires payload-level evidence: exact selected text, exact media start/end/duration, commentary, and source URL must match across browser UI, production `POST /api/annotations`, stored annotation, and permalink.
+
+p50 proof: one normal annotation publishes. p95 proof: exact quote/timecode preservation plus invalid-duration rejection and source-link integrity.
+```
+
+## #24 Real X/Google Auth And Extension Handoff
+
+```md
+Submission packet reconciliation update:
+
+PR #31 moved production auth into an honest limited state: sign-in UI is no longer inert, and missing provider config fails visibly instead of creating fake production sessions. The docs now classify #24 as blocked by human credentials/secrets plus remaining provider implementation.
+
+Close requires real Google/X apps and secrets, token exchange, user/session creation, secure cookies, logout/session invalidation, and authenticated extension-token handoff. p95 proof should include invalid/replayed state rejection and anonymous extension-token denial.
+```
+
+## #26 Audio Commentary And 240p Media Policy
+
+```md
+Submission packet reconciliation update:
+
+The docs now classify audio/240p as deployed but limited for audio intents and not yet implemented for owned-media 240p. Text commentary works; production audio upload currently returns `intent-created` because R2 is not enabled and `MEDIA_BUCKET` is omitted.
+
+Close requires R2 or an alternate durable storage path, finalize/metadata validation, permalink audio proof, and a product/legal decision for owned-video 240p/sub-480p handling. Third-party media should remain source-linked by reference unless an owned-upload path is explicitly approved.
+```
+
+## #28 Final Bounty Submission Package
+
+```md
+Submission packet reconciliation update:
+
+`docs/submission-packet.md` now has live URLs, status buckets, issue-linked acceptance notes, p50/p95 proof requirements, and copy for an honest known-limitations disclosure.
+
+Close when the human submitter either waits for #22/#23/#24/#26/#30 to close or approves submitting with the disclosed gaps: real OAuth, production extension p95 proof, durable recorded-audio storage, owned-media 240p policy, and GitHub deploy-from-main.
+```
+
+## #30 Local Chrome Extension Install And Bounty Smoke Verification
+
+```md
+Submission packet reconciliation update:
+
+The extension proof is documented as working locally but not yet production-p95 complete. Existing local evidence proves `dist/extension` can load unpacked, open the side panel, save localhost API base, capture current tab, and publish to the local API.
+
+Close requires the rebuilt extension to save the production Worker URL, publish one production annotation, preserve exact selected text, preserve real media current time/start/end/duration, block >90 seconds before network publish, and document audio/microphone behavior against the current #26 storage limitation.
+```


### PR DESCRIPTION
## Summary
- Reconcile bounty readiness docs into working/deployed-limited/blocked/not-yet-implemented buckets
- Add p50 vs p95 proof requirements for open bounty gaps
- Add concise issue-comment drafts for the seven open tickets

## Issues
Refs #21, #28, #22, #23, #24, #26, #30

## Verification
- git diff --check

## Notes
This is documentation/report-only. It intentionally does not claim full bounty completion while OAuth, deploy-from-main, extension p95 smoke, and audio/R2 remain open.