### PR TITLE
ci: harden Cloudflare deploy preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,16 +49,45 @@ jobs:
       - name: Build
         run: npm run build
 
-  deploy-production:
-    name: Deploy production Cloudflare
+  cloudflare_production_preflight:
+    name: Cloudflare production preflight
     needs: verify
     runs-on: ubuntu-latest
-    # CLOUDFLARE_DEPLOY_ENABLED is a repository-level deploy gate. Production
-    # credentials remain in the GitHub production environment.
     if: >-
-      vars.CLOUDFLARE_DEPLOY_ENABLED == 'true' &&
       github.ref == 'refs/heads/main' &&
-      (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy_production))
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    outputs:
+      should_deploy: ${{ steps.preflight.outputs.should_deploy }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Report Cloudflare deploy readiness
+        id: preflight
+        run: npm run cf:preflight:ci -- --summary --set-output
+        env:
+          CLOUDFLARE_DEPLOY_ENABLED: ${{ vars.CLOUDFLARE_DEPLOY_ENABLED }}
+          DEPLOY_PRODUCTION_INPUT: ${{ inputs.deploy_production }}
+          CLOUDFLARE_ACCOUNT_ID_PRESENT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
+          CLOUDFLARE_API_TOKEN_PRESENT: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
+
+  deploy-production:
+    name: Deploy production Cloudflare
+    needs:
+      - verify
+      - cloudflare_production_preflight
+    runs-on: ubuntu-latest
+    # Deployment stays fail-closed: the visible preflight job decides whether the
+    # explicit repository gate and main-branch trigger allow production mutation.
+    if: >-
+      always() &&
+      needs.verify.result == 'success' &&
+      needs.cloudflare_production_preflight.outputs.should_deploy == 'true'
     environment:
       name: production
       url: ${{ steps.deploy-pages.outputs.deployment-url }}
@@ -77,6 +106,14 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Verify production Cloudflare credentials
+        run: npm run cf:preflight:ci -- --summary --require-secrets
+        env:
+          CLOUDFLARE_DEPLOY_ENABLED: ${{ vars.CLOUDFLARE_DEPLOY_ENABLED }}
+          DEPLOY_PRODUCTION_INPUT: ${{ inputs.deploy_production }}
+          CLOUDFLARE_ACCOUNT_ID_PRESENT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
+          CLOUDFLARE_API_TOKEN_PRESENT: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
 
       - name: Apply remote D1 migrations
         run: npm run cf:migrate:production

--- a/docs/cloudflare-architecture.md
+++ b/docs/cloudflare-architecture.md
@@ -141,6 +141,12 @@ Suggested bindings:
 - Rate-limit publish, claim filing, and engagement mutation endpoints.
 - Create explicit moderation states: `open`, `needs_info`, `accepted`, `rejected`, `withdrawn`.
 
+## Deployment Control Plane
+
+Production deployment is owned by GitHub Actions, not local laptops. The ordered path is `verify`, `cloudflare_production_preflight`, then `deploy-production` against the GitHub `production` environment. The preflight job makes skipped deployments visible when `CLOUDFLARE_DEPLOY_ENABLED` is not `true`; the production job repeats credential preflight after environment approval so missing Cloudflare secrets fail before D1 migrations, Worker deploy, or Pages deploy can mutate production.
+
+Local Wrangler remains a guarded fallback for resource bootstrap and emergency deploys. The fallback must use the same `apps/api/wrangler.production.jsonc` config and should not bypass the documented GitHub environment secret setup for normal releases.
+
 ## Architecture Sources
 
 - Cloudflare Workers Static Assets: https://developers.cloudflare.com/workers/static-assets/

--- a/docs/cloudflare-cli.md
+++ b/docs/cloudflare-cli.md
@@ -18,7 +18,10 @@ export CLOUDFLARE_ACCOUNT_ID=...
 export CLOUDFLARE_API_TOKEN=...
 npm run cf:setup:production -- --apply --resources --pages
 git diff apps/api/wrangler.production.jsonc
-npm run cf:setup:production -- --apply --github
+gh api --method PUT repos/ChaiWithJai/annotated-canvas/environments/production
+printf '%s' "$CLOUDFLARE_ACCOUNT_ID" | gh secret set CLOUDFLARE_ACCOUNT_ID --env production --body-file -
+printf '%s' "$CLOUDFLARE_API_TOKEN" | gh secret set CLOUDFLARE_API_TOKEN --env production --body-file -
+gh variable set CLOUDFLARE_DEPLOY_ENABLED --body false
 ```
 
 Omit `--pages` when the Cloudflare Pages project already exists. If D1 and KV were created outside this script, update `apps/api/wrangler.production.jsonc` with those IDs before enabling the GitHub deploy gate.
@@ -61,7 +64,46 @@ export CLOUDFLARE_API_TOKEN=...
 npm run cf:setup:production -- --apply --github
 ```
 
-When `--github` is present, the script creates or reuses the GitHub `production` environment, stores Cloudflare credentials there, and enables the repository-level `CLOUDFLARE_DEPLOY_ENABLED` gate. Use `CLOUDFLARE_GITHUB_ENVIRONMENT=...` to target a different GitHub environment. Configure required reviewers for that environment in GitHub repo settings before enabling unattended production deploys.
+When `--github` is present, the script creates or reuses the GitHub `production` environment, stores Cloudflare credentials there, and enables the repository-level `CLOUDFLARE_DEPLOY_ENABLED` gate. For a more conservative rollout, run the explicit `gh` commands above, keep `CLOUDFLARE_DEPLOY_ENABLED=false`, confirm required reviewers on the `production` environment, then set the gate to `true` only when the account owner approves the first deploy-from-main. Use `CLOUDFLARE_GITHUB_ENVIRONMENT=...` to target a different GitHub environment.
+
+## Required Cloudflare API Token
+
+Create a custom Cloudflare user API token scoped to the single production account. Cloudflare's GitHub Actions documentation requires `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` for non-interactive Wrangler deploys, and Cloudflare recommends scoping tokens down to only the account and zone resources needed.
+
+Required account permissions for this MVP workflow:
+
+| Scope | Permission | Why |
+| --- | --- | --- |
+| Account | Account Settings: Read | Lets Wrangler resolve account-level settings during deploy. |
+| Account | Workers Scripts: Edit | Deploys `annotated-canvas-api` and its bindings. |
+| Account | Cloudflare Pages: Edit | Deploys the `annotated-canvas` Pages project. |
+| Account | D1: Edit | Applies production D1 migrations. |
+| Account | Workers KV Storage: Edit | Reads and manages the production `SESSION_KV` binding. |
+| Account | Queues: Edit | Deploys Worker queue producer/consumer bindings. |
+| User | User Details: Read | Lets Wrangler identify the token user. |
+| User | Memberships: Read | Lets Wrangler verify account membership for user tokens. |
+
+Do not include zone resources for the current `workers.dev` and `pages.dev` deployment. Add `Zone > Workers Routes: Edit` only when a custom domain route is introduced, scoped to that one zone. Add `Account > Workers R2 Storage: Edit` only after R2 is enabled and the production `MEDIA_BUCKET` binding is restored. Durable Object migrations are carried by the Worker deploy; Cloudflare does not expose a separate Durable Objects API-token permission in the current permission table.
+
+Store the token only in the GitHub `production` environment:
+
+```bash
+gh api --method PUT repos/ChaiWithJai/annotated-canvas/environments/production
+printf '%s' "$CLOUDFLARE_ACCOUNT_ID" | gh secret set CLOUDFLARE_ACCOUNT_ID --env production --body-file -
+printf '%s' "$CLOUDFLARE_API_TOKEN" | gh secret set CLOUDFLARE_API_TOKEN --env production --body-file -
+gh variable set CLOUDFLARE_DEPLOY_ENABLED --body false
+gh secret list --env production
+gh variable get CLOUDFLARE_DEPLOY_ENABLED
+```
+
+After the production environment has required reviewers and the owner approves deploy-from-main:
+
+```bash
+gh variable set CLOUDFLARE_DEPLOY_ENABLED --body true
+gh workflow run "CI and Deploy" --ref main -f deploy_production=true
+```
+
+`cloudflare_production_preflight` now reports whether the deploy gate, trigger, and visible secret names are ready. The production job repeats the same preflight inside the GitHub `production` environment and fails before any Wrangler command if `CLOUDFLARE_ACCOUNT_ID` or `CLOUDFLARE_API_TOKEN` is missing.
 
 Resource creation and production config patching still need Cloudflare API access through Wrangler. Use this when the target account is available from the CLI:
 
@@ -88,7 +130,7 @@ npm run cf:setup:production -- --apply --github
 gh workflow run "CI and Deploy" --ref main -f deploy_production=true
 ```
 
-This is HITL-required because the token value and approval to enable `CLOUDFLARE_DEPLOY_ENABLED=true` must come from the account owner. Without those credentials, engineers can still run dry runs, verify workflow conditions, update docs, and confirm the latest verification job status.
+This is HITL-required because the token value and approval to enable `CLOUDFLARE_DEPLOY_ENABLED=true` must come from the account owner. Without those credentials, engineers can still run dry runs, verify workflow conditions, update docs, and confirm the latest verification job status. Keep the repository variable at `false` until the secrets are present and the first production deploy has an assigned reviewer.
 
 Auth and media gates are separate:
 
@@ -118,3 +160,5 @@ The first Worker runs services in-process so local development stays simple. Whe
 - Queues JavaScript APIs: https://developers.cloudflare.com/queues/configuration/javascript-apis/
 - Queues dead-letter queues: https://developers.cloudflare.com/queues/configuration/dead-letter-queues/
 - D1 Worker API: https://developers.cloudflare.com/d1/worker-api/d1-database/
+- Cloudflare API token permissions: https://developers.cloudflare.com/fundamentals/api/reference/permissions/
+- Cloudflare GitHub Actions authentication: https://developers.cloudflare.com/workers/ci-cd/external-cicd/github-actions/

--- a/docs/deployment-devops.md
+++ b/docs/deployment-devops.md
@@ -26,10 +26,11 @@ Native Cloudflare Git integration can be added later for preview ergonomics, but
 
 ## GitHub Actions Workflow
 
-The workflow in `.github/workflows/ci.yml` has two jobs:
+The workflow in `.github/workflows/ci.yml` has three production-relevant jobs:
 
 1. `verify` runs on pull requests and pushes to `main`.
-2. `deploy-production` runs only after `verify` passes on a push to `main`, or after a manual `workflow_dispatch` on `main` with `deploy_production=true`.
+2. `cloudflare_production_preflight` runs after `verify` on `main` push or manual dispatch and writes a summary explaining whether production deploy is eligible or skipped.
+3. `deploy-production` runs only when preflight says the explicit deploy gate is enabled on `main` and the event is a `push` or a manual `workflow_dispatch` with `deploy_production=true`.
 
 Verification commands:
 
@@ -44,6 +45,7 @@ npm run build
 Production deployment commands:
 
 ```bash
+npm run cf:preflight:ci -- --summary --require-secrets
 npm run cf:migrate:production
 npm exec -- wrangler deploy --config apps/api/wrangler.production.jsonc
 VITE_API_BASE_URL=https://annotated-canvas-api.<account>.workers.dev npm run build:web
@@ -63,23 +65,35 @@ Set these in the GitHub `production` environment, not only at repository level:
 
 `npm run cf:setup:production -- --apply --github` creates or reuses this environment and writes these secrets through `gh`. Configure required reviewers for the environment in GitHub repo settings before enabling unattended production deploys.
 
+The conservative CLI path keeps the deploy gate disabled until a human explicitly enables it:
+
+```bash
+gh api --method PUT repos/ChaiWithJai/annotated-canvas/environments/production
+printf '%s' "$CLOUDFLARE_ACCOUNT_ID" | gh secret set CLOUDFLARE_ACCOUNT_ID --env production --body-file -
+printf '%s' "$CLOUDFLARE_API_TOKEN" | gh secret set CLOUDFLARE_API_TOKEN --env production --body-file -
+gh variable set CLOUDFLARE_DEPLOY_ENABLED --body false
+```
+
 Set this as a repository-level variable because it controls whether the production deploy job is allowed to run:
 
 | Variable | Purpose |
 | --- | --- |
 | `CLOUDFLARE_DEPLOY_ENABLED` | Set to `true` only after production resource IDs are committed and the GitHub `production` environment contains valid Cloudflare secrets. |
 
-The Cloudflare API token should be narrowly scoped. Minimum practical permissions:
+The Cloudflare API token should be narrowly scoped to the single production account. Minimum practical permissions for the current `workers.dev` plus Pages deployment:
 
-- Workers Scripts: Edit
-- Workers Routes: Edit, if production uses custom routes
-- Cloudflare Pages: Edit
-- Account Settings: Read
-- D1: Edit
-- Workers KV Storage: Edit
-- R2: Edit
-- Queues: Edit
-- Durable Objects: Edit, when applying Durable Object migrations through Worker deploys
+| Resource | Permission |
+| --- | --- |
+| Account | Account Settings: Read |
+| Account | Workers Scripts: Edit |
+| Account | Cloudflare Pages: Edit |
+| Account | D1: Edit |
+| Account | Workers KV Storage: Edit |
+| Account | Queues: Edit |
+| User | User Details: Read |
+| User | Memberships: Read |
+
+Do not grant zone resources for the current deployment. Add `Zone > Workers Routes: Edit` only when a custom domain route is introduced, and scope it to that zone. Add `Account > Workers R2 Storage: Edit` only after R2 is enabled and `MEDIA_BUCKET` returns to `apps/api/wrangler.production.jsonc`. Durable Object migrations are part of the Worker deploy and do not require a separate Cloudflare API-token permission.
 
 Do not put application secrets in `vars` inside `wrangler.jsonc`. Use Worker secrets for sensitive values. With the GitHub-first path, run these with `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` exported, or perform the equivalent through an approved secret-management workflow:
 
@@ -112,6 +126,28 @@ Confirm `apps/api/wrangler.production.jsonc` contains the generated identifiers 
 - preview/staging IDs under `env.preview` or `env.staging` when those environments are added
 
 The bootstrap script patches the D1 and KV identifiers automatically when it can resolve them from Wrangler output. The local Wrangler file intentionally uses demo values. Production deploys use `apps/api/wrangler.production.jsonc`, which intentionally contains placeholder IDs until Cloudflare resources are created.
+
+## Production Deploy Trigger
+
+Once the production environment contains secrets, the environment has required reviewers, and the deploy gate is approved:
+
+```bash
+gh variable set CLOUDFLARE_DEPLOY_ENABLED --body true
+gh workflow run "CI and Deploy" --ref main -f deploy_production=true
+```
+
+The same deploy path also runs on future pushes to `main` while `CLOUDFLARE_DEPLOY_ENABLED=true`. Set the variable back to `false` to freeze production deployment without changing the workflow:
+
+```bash
+gh variable set CLOUDFLARE_DEPLOY_ENABLED --body false
+```
+
+Acceptance criteria for proving #22:
+
+- `verify` passes on `main`.
+- `cloudflare_production_preflight` reports the deploy gate enabled on `refs/heads/main`.
+- `deploy-production` reaches the GitHub `production` environment and fails before Wrangler if either Cloudflare secret is absent.
+- With both secrets present, `deploy-production` applies production D1 migrations, deploys the Worker, builds web with the deployed Worker URL, deploys Pages, and writes Worker/Pages URLs to the step summary.
 
 ## Local And Remote D1 Migrations
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cf:migrate:remote": "wrangler d1 migrations apply annotated_canvas --remote --config apps/api/wrangler.jsonc",
     "cf:migrate:production": "wrangler d1 migrations apply annotated_canvas --remote --config apps/api/wrangler.production.jsonc",
     "cf:queues:create": "wrangler queues create annotated-canvas-jobs && wrangler queues create annotated-canvas-dlq",
+    "cf:preflight:ci": "node scripts/cloudflare/preflight-ci.mjs",
     "cf:setup:production": "node scripts/cloudflare/setup-production.mjs",
     "cf:deploy:production": "node scripts/cloudflare/setup-production.mjs --apply --deploy --pages"
   },

--- a/scripts/cloudflare/preflight-ci.mjs
+++ b/scripts/cloudflare/preflight-ci.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+
+const args = new Set(process.argv.slice(2));
+const shouldRequireSecrets = args.has("--require-secrets");
+const shouldWriteSummary = args.has("--summary");
+const shouldSetOutput = args.has("--set-output");
+
+const requiredSecretFlags = [
+  ["CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_ACCOUNT_ID_PRESENT"],
+  ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_API_TOKEN_PRESENT"]
+];
+
+function value(name) {
+  return process.env[name] ?? "";
+}
+
+function bool(valueToParse) {
+  return valueToParse === "true";
+}
+
+function checked(condition) {
+  return condition ? "ok" : "missing";
+}
+
+function writeGithubOutput(name, outputValue) {
+  const outputPath = value("GITHUB_OUTPUT");
+  if (!outputPath) return;
+  appendFileSync(outputPath, `${name}=${outputValue}\n`);
+}
+
+function appendSummary(markdown) {
+  const summaryPath = value("GITHUB_STEP_SUMMARY");
+  if (!summaryPath) return;
+  appendFileSync(summaryPath, `${markdown}\n`);
+}
+
+function main() {
+  const eventName = value("GITHUB_EVENT_NAME");
+  const ref = value("GITHUB_REF");
+  const deployInput = value("DEPLOY_PRODUCTION_INPUT");
+  const deployGateEnabled = value("CLOUDFLARE_DEPLOY_ENABLED") === "true";
+  const isMain = ref === "refs/heads/main";
+  const triggerAllowsDeploy = eventName === "push" || (eventName === "workflow_dispatch" && deployInput === "true");
+  const shouldDeploy = deployGateEnabled && isMain && triggerAllowsDeploy;
+  const missingSecrets = requiredSecretFlags
+    .filter(([, flag]) => !bool(value(flag)))
+    .map(([secret]) => secret);
+
+  const blockers = [];
+  if (!isMain) blockers.push("workflow ref is not refs/heads/main");
+  if (!triggerAllowsDeploy) blockers.push("event is not a main push and workflow_dispatch did not set deploy_production=true");
+  if (!deployGateEnabled) blockers.push("repository variable CLOUDFLARE_DEPLOY_ENABLED is not true");
+  if (shouldRequireSecrets && missingSecrets.length > 0) {
+    blockers.push(`missing production environment secrets: ${missingSecrets.join(", ")}`);
+  }
+
+  const lines = [
+    "## Cloudflare production preflight",
+    "",
+    `- Ref: \`${ref || "(unset)"}\``,
+    `- Event: \`${eventName || "(unset)"}\``,
+    `- Manual deploy input: \`${deployInput || "false"}\``,
+    `- Deploy gate \`CLOUDFLARE_DEPLOY_ENABLED\`: ${deployGateEnabled ? "enabled" : "disabled"}`,
+    `- Production deploy decision: ${shouldDeploy ? "eligible" : "skipped"}`,
+    `- Secret check mode: ${shouldRequireSecrets ? "required before deploy" : "report only"}`,
+    "",
+    "| Check | Status |",
+    "| --- | --- |",
+    `| main branch | ${checked(isMain)} |`,
+    `| deploy trigger | ${checked(triggerAllowsDeploy)} |`,
+    `| deploy gate variable | ${checked(deployGateEnabled)} |`,
+    ...requiredSecretFlags.map(([secret, flag]) => `| ${secret} visible in this job | ${checked(bool(value(flag)))} |`)
+  ];
+
+  if (blockers.length > 0) {
+    lines.push("", "Blocked or skipped because:");
+    for (const blocker of blockers) lines.push(`- ${blocker}`);
+  }
+
+  lines.push(
+    "",
+    "Required human setup is documented in `docs/cloudflare-cli.md` and `docs/deployment-devops.md`."
+  );
+
+  const summary = lines.join("\n");
+  process.stdout.write(`${summary}\n`);
+  if (shouldWriteSummary) appendSummary(summary);
+  if (shouldSetOutput) writeGithubOutput("should_deploy", shouldDeploy ? "true" : "false");
+
+  if (shouldRequireSecrets && missingSecrets.length > 0) {
+    for (const secret of missingSecrets) {
+      process.stdout.write(`::error::Missing required GitHub production environment secret ${secret}.\n`);
+    }
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add a visible Cloudflare production preflight job so skipped deploys explain what is missing
- Keep deploy fail-closed behind `CLOUDFLARE_DEPLOY_ENABLED=true` and add secret preflight inside the production environment before Wrangler mutations
- Document exact GitHub secret/variable commands and Cloudflare API token scope/resource requirements

## Issues
Refs #22

## Verification
- node --check scripts/cloudflare/preflight-ci.mjs
- preflight disabled-gate, missing-secret, and all-present dry runs
- workflow YAML parse via Ruby
- npm run typecheck
- npm test
- npm run test:workers
- npm run build
- git diff --check

## Remaining blocker
GitHub deploy-from-main still requires human setup of the Cloudflare account ID/API token, production environment protection, and `CLOUDFLARE_DEPLOY_ENABLED=true`.