### PR TITLE
feat(extension): harden MVP smoke path

### DIFF
--- a/apps/extension/src/service-worker.ts
+++ b/apps/extension/src/service-worker.ts
@@ -9,12 +9,13 @@ chrome.runtime.onInstalled.addListener(() => {
 });
 
 chrome.contextMenus.onClicked.addListener((info, tab) => {
-  if (info.menuItemId !== "annotated-capture-selection" || !tab?.id) return;
+  const selectionText = info.selectionText?.trim();
+  if (info.menuItemId !== "annotated-capture-selection" || !tab?.id || !selectionText) return;
 
   chrome.storage.local.set({
     pendingCapture: {
       capture_method: "selection",
-      selection_text: info.selectionText,
+      selection_text: selectionText,
       source_url: tab.url,
       title: tab.title,
       tab_id: String(tab.id)

--- a/apps/extension/src/sidepanel/SidePanel.tsx
+++ b/apps/extension/src/sidepanel/SidePanel.tsx
@@ -1,13 +1,18 @@
 import { SourceRefSchema, toSourceDomain } from "@annotated/contracts";
 import { Button, SourcePill } from "@annotated/ui";
-import { Clock, FileText, Layers, Mic, Scissors, Send, Settings, Square, UserCircle } from "lucide-react";
+import { Clock, FileText, Layers, Mic, RotateCcw, Save, Scissors, Send, Settings, Square, UserCircle } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
+  DEFAULT_API_BASE,
+  PRODUCTION_API_BASE,
   readApiBase,
   publishAnnotation,
   readActiveTabContext,
+  readCaptureDraft,
   readPendingCapture,
   saveApiBase,
+  saveCaptureDraft,
+  type CaptureDraft,
   type PageCaptureContext
 } from "./api";
 
@@ -35,6 +40,8 @@ export function SidePanel() {
   const [pageContext, setPageContext] = useState<PageCaptureContext | null>(null);
   const [apiBaseUrl, setApiBaseUrl] = useState("");
   const [settingsStatus, setSettingsStatus] = useState<string | null>(null);
+  const [savedDraft, setSavedDraft] = useState<CaptureDraft | null>(null);
+  const [draftStatus, setDraftStatus] = useState<string | null>(null);
   const recorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<BlobPart[]>([]);
 
@@ -69,6 +76,7 @@ export function SidePanel() {
 
   useEffect(() => {
     void readApiBase().then(setApiBaseUrl);
+    void readCaptureDraft().then(setSavedDraft);
   }, []);
 
   function parseTimeInput(value: string): number {
@@ -153,6 +161,31 @@ export function SidePanel() {
     const nextApiBase = await saveApiBase(apiBaseUrl);
     setApiBaseUrl(nextApiBase);
     setSettingsStatus("Saved.");
+  }
+
+  async function saveDraft() {
+    const startSeconds = parseTimeInput(startTime);
+    const endSeconds = parseTimeInput(endTime);
+    const nextDraft = await saveCaptureDraft({
+      context: pageContext ?? {},
+      commentary,
+      captureKind,
+      range: { start_seconds: startSeconds, end_seconds: endSeconds }
+    });
+    setSavedDraft(nextDraft);
+    setDraftStatus("Draft saved locally.");
+  }
+
+  function restoreDraft(draft: CaptureDraft) {
+    setPageContext(draft.context);
+    setCaptureKind(draft.captureKind);
+    setCommentary(draft.commentary);
+    if (draft.range) {
+      setStartTime(formatTimeInput(draft.range.start_seconds));
+      setEndTime(formatTimeInput(draft.range.end_seconds));
+    }
+    setMode("context");
+    setDraftStatus("Draft restored.");
   }
 
   return (
@@ -244,6 +277,13 @@ export function SidePanel() {
             </button>
             {audioBlob ? <span>Voice note ready</span> : null}
           </div>
+          <div className="draft-actions">
+            <Button tone="secondary" type="button" onClick={saveDraft}>
+              <Save size={15} aria-hidden="true" />
+              Save draft
+            </Button>
+            {draftStatus ? <span>{draftStatus}</span> : null}
+          </div>
         </section>
       ) : mode === "settings" ? (
         <section className="settings-pane">
@@ -259,23 +299,49 @@ export function SidePanel() {
               inputMode="url"
             />
           </label>
+          <div className="preset-row" aria-label="API presets">
+            <button type="button" onClick={() => setApiBaseUrl(DEFAULT_API_BASE)}>
+              Local
+            </button>
+            <button type="button" onClick={() => setApiBaseUrl(PRODUCTION_API_BASE)}>
+              Production
+            </button>
+          </div>
           <p>Use localhost for local testing or the deployed Worker URL for review.</p>
           <Button tone="secondary" onClick={saveSettings}>
             Save settings
           </Button>
           {settingsStatus ? <span>{settingsStatus}</span> : null}
         </section>
+      ) : mode === "drafts" ? (
+        <section className="draft-pane">
+          {savedDraft ? (
+            <article className="draft-card">
+              <div>
+                <strong>{savedDraft.context.title || "Untitled source"}</strong>
+                <span>{savedDraft.captureKind === "text" ? "Selected text" : "Time range"}</span>
+              </div>
+              <p>{savedDraft.commentary || "No commentary yet."}</p>
+              <Button tone="secondary" type="button" onClick={() => restoreDraft(savedDraft)}>
+                <RotateCcw size={15} aria-hidden="true" />
+                Restore draft
+              </Button>
+            </article>
+          ) : (
+            <p>No local draft saved yet.</p>
+          )}
+        </section>
       ) : (
         <section className="empty-pane">
-          <p>No saved items yet.</p>
+          <p>Published items appear in the API feed after publish.</p>
         </section>
       )}
 
       <footer className="sidepanel-footer">
         {error ? <p className="sidepanel-error">{error}</p> : null}
         <div className="sync-row">
-          <span>Signed out</span>
           <UserCircle size={16} aria-hidden="true" />
+          <span>Signed out: production publishes use the demo API author until extension OAuth handoff lands.</span>
         </div>
         <Button tone="primary" onClick={publish} disabled={status === "publishing"}>
           <Send size={16} aria-hidden="true" />

--- a/apps/extension/src/sidepanel/api.test.ts
+++ b/apps/extension/src/sidepanel/api.test.ts
@@ -1,5 +1,31 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { publishAnnotation, readApiBase, saveApiBase } from "./api";
+import {
+  PRODUCTION_API_BASE,
+  publishAnnotation,
+  readApiBase,
+  readCaptureDraft,
+  readPendingCapture,
+  saveApiBase,
+  saveCaptureDraft
+} from "./api";
+
+function stubChromeStorage(initialValues: Record<string, unknown> = {}) {
+  const storage = new Map<string, unknown>(Object.entries(initialValues));
+  vi.stubGlobal("chrome", {
+    storage: {
+      local: {
+        get: vi.fn(async (key: string) => ({ [key]: storage.get(key) })),
+        set: vi.fn(async (value: Record<string, unknown>) => {
+          Object.entries(value).forEach(([key, nextValue]) => storage.set(key, nextValue));
+        }),
+        remove: vi.fn(async (key: string) => {
+          storage.delete(key);
+        })
+      }
+    }
+  });
+  return storage;
+}
 
 describe("extension publish API", () => {
   afterEach(() => {
@@ -59,6 +85,61 @@ describe("extension publish API", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("rejects p95 audio commentary publishes above the 90 second cap before upload or publish fetch", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    await expect(
+      publishAnnotation({
+        context: {
+          source_url: "https://example.com/audio",
+          title: "Example audio",
+          media: { current_time: 0, kind: "audio" }
+        },
+        commentary: "This audio note should not upload.",
+        captureKind: "video",
+        range: {
+          start_seconds: 0,
+          end_seconds: 91
+        },
+        audioBlob: new Blob(["audio"], { type: "audio/webm" })
+      })
+    ).rejects.toThrow("range_too_long");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("publishes exact p95 selected text from the context-menu capture path", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ annotation: { id: "ann_text" } }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" }
+      })
+    );
+
+    await publishAnnotation({
+      context: {
+        source_url: "https://example.com/article",
+        title: "Example article",
+        selection_text: "  Exact selected quote for smoke evidence.  "
+      },
+      commentary: "Selected text smoke note.",
+      captureKind: "text"
+    });
+
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(request.body));
+    expect(body.clip).toMatchObject({
+      kind: "text",
+      text: {
+        quote: "Exact selected quote for smoke evidence."
+      }
+    });
+    expect(body.client_context).toMatchObject({
+      surface: "extension",
+      capture_method: "selection"
+    });
+  });
+
   it("uploads recorded audio commentary before publishing an audio annotation", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
@@ -100,17 +181,7 @@ describe("extension publish API", () => {
   });
 
   it("uses the stored API base so review builds can target production without source edits", async () => {
-    const storage = new Map<string, string>();
-    vi.stubGlobal("chrome", {
-      storage: {
-        local: {
-          get: vi.fn(async (key: string) => ({ [key]: storage.get(key) })),
-          set: vi.fn(async (value: Record<string, string>) => {
-            Object.entries(value).forEach(([key, nextValue]) => storage.set(key, nextValue));
-          })
-        }
-      }
-    });
+    stubChromeStorage();
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ annotation: { id: "ann_test" } }), {
         status: 201,
@@ -118,8 +189,8 @@ describe("extension publish API", () => {
       })
     );
 
-    await saveApiBase("https://annotated-canvas-api.example.workers.dev/");
-    expect(await readApiBase()).toBe("https://annotated-canvas-api.example.workers.dev");
+    await saveApiBase(`${PRODUCTION_API_BASE}/`);
+    expect(await readApiBase()).toBe(PRODUCTION_API_BASE);
 
     await publishAnnotation({
       context: {
@@ -132,7 +203,51 @@ describe("extension publish API", () => {
     });
 
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
-      "https://annotated-canvas-api.example.workers.dev/api/annotations"
+      `${PRODUCTION_API_BASE}/api/annotations`
     );
+  });
+
+  it("clears stale pending selected-text captures after reading them once", async () => {
+    const storage = stubChromeStorage({
+      pendingCapture: {
+        source_url: "https://example.com/article",
+        title: "Example article",
+        selection_text: "Selected quote"
+      }
+    });
+
+    await expect(readPendingCapture()).resolves.toMatchObject({
+      selection_text: "Selected quote"
+    });
+    expect(storage.has("pendingCapture")).toBe(false);
+  });
+
+  it("persists a local capture draft with trimmed commentary for repeatable smoke runs", async () => {
+    stubChromeStorage();
+
+    const draft = await saveCaptureDraft({
+      context: {
+        source_url: "https://example.com/video",
+        title: "Example video"
+      },
+      commentary: "  Draft commentary for smoke.  ",
+      captureKind: "video",
+      range: {
+        start_seconds: 12,
+        end_seconds: 70
+      }
+    });
+
+    expect(draft).toMatchObject({
+      commentary: "Draft commentary for smoke.",
+      captureKind: "video",
+      range: {
+        start_seconds: 12,
+        end_seconds: 70
+      }
+    });
+    await expect(readCaptureDraft()).resolves.toMatchObject({
+      commentary: "Draft commentary for smoke."
+    });
   });
 });

--- a/apps/extension/src/sidepanel/api.ts
+++ b/apps/extension/src/sidepanel/api.ts
@@ -1,7 +1,10 @@
 import { AnnotationCreateSchema, SourceRefSchema, toSourceDomain } from "@annotated/contracts";
 
 export const DEFAULT_API_BASE = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8787";
+export const PRODUCTION_API_BASE = "https://annotated-canvas-api.jaybhagat841.workers.dev";
 const API_BASE_STORAGE_KEY = "apiBaseUrl";
+const PENDING_CAPTURE_STORAGE_KEY = "pendingCapture";
+const CAPTURE_DRAFT_STORAGE_KEY = "captureDraft";
 
 export interface PageCaptureContext {
   source_url?: string;
@@ -23,6 +26,17 @@ export interface PublishOptions {
     end_seconds: number;
   };
   audioBlob?: Blob | null;
+}
+
+export interface CaptureDraft {
+  context: PageCaptureContext;
+  commentary: string;
+  captureKind: "text" | "video";
+  range?: {
+    start_seconds: number;
+    end_seconds: number;
+  };
+  saved_at: string;
 }
 
 function normalizeApiBase(value: string): string {
@@ -64,8 +78,36 @@ export async function readActiveTabContext(): Promise<PageCaptureContext | null>
 
 export async function readPendingCapture(): Promise<PageCaptureContext | null> {
   if (!globalThis.chrome?.storage?.local) return null;
-  const result = await chrome.storage.local.get("pendingCapture");
-  return (result.pendingCapture as PageCaptureContext | undefined) ?? null;
+  const result = await chrome.storage.local.get(PENDING_CAPTURE_STORAGE_KEY);
+  const pending = (result[PENDING_CAPTURE_STORAGE_KEY] as PageCaptureContext | undefined) ?? null;
+  if (pending && chrome.storage.local.remove) {
+    await chrome.storage.local.remove(PENDING_CAPTURE_STORAGE_KEY);
+  }
+  return pending;
+}
+
+export async function readCaptureDraft(): Promise<CaptureDraft | null> {
+  if (!globalThis.chrome?.storage?.local) return null;
+  const result = await chrome.storage.local.get(CAPTURE_DRAFT_STORAGE_KEY);
+  return (result[CAPTURE_DRAFT_STORAGE_KEY] as CaptureDraft | undefined) ?? null;
+}
+
+export async function saveCaptureDraft(draft: Omit<CaptureDraft, "saved_at">): Promise<CaptureDraft> {
+  const savedDraft = {
+    ...draft,
+    commentary: draft.commentary.trim(),
+    context: {
+      ...draft.context,
+      selection_text: draft.context.selection_text?.trim()
+    },
+    saved_at: new Date().toISOString()
+  };
+  if (globalThis.chrome?.storage?.local) {
+    await chrome.storage.local.set({
+      [CAPTURE_DRAFT_STORAGE_KEY]: savedDraft
+    });
+  }
+  return savedDraft;
 }
 
 async function uploadAudioCommentary(audioBlob: Blob): Promise<string> {
@@ -95,6 +137,9 @@ export async function publishAnnotation(options: PublishOptions) {
   const startSeconds = Math.max(0, Math.floor(range?.start_seconds ?? currentTime));
   const endSeconds = Math.max(startSeconds + 1, Math.floor(range?.end_seconds ?? currentTime + 47));
   const durationSeconds = endSeconds - startSeconds;
+  if (captureKind === "video" && durationSeconds > 90) {
+    throw new Error("range_too_long");
+  }
   const audioAssetId = audioBlob ? await uploadAudioCommentary(audioBlob) : null;
   const payload = AnnotationCreateSchema.parse({
     clip:
@@ -103,7 +148,7 @@ export async function publishAnnotation(options: PublishOptions) {
             kind: "text",
             source,
             text: {
-              quote: context.selection_text || "Selected source text for annotation."
+              quote: context.selection_text?.trim() || "Selected source text for annotation."
             }
           }
         : {

--- a/apps/extension/src/sidepanel/sidepanel.css
+++ b/apps/extension/src/sidepanel/sidepanel.css
@@ -192,9 +192,59 @@ body {
   font-size: 12px;
 }
 
+.draft-actions {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+}
+
+.draft-actions .ac-button {
+  min-height: 36px;
+}
+
+.draft-actions span {
+  color: var(--ac-muted);
+  font-size: 12px;
+}
+
 .empty-pane {
   padding: 28px 20px;
   color: var(--ac-muted);
+}
+
+.draft-pane {
+  padding: 22px 20px;
+  color: var(--ac-muted);
+}
+
+.draft-card {
+  border: 1px solid var(--ac-border);
+  border-radius: var(--ac-radius);
+  padding: 14px;
+  display: grid;
+  gap: 12px;
+}
+
+.draft-card div {
+  display: grid;
+  gap: 4px;
+}
+
+.draft-card strong {
+  color: var(--ac-text);
+  font-size: 14px;
+}
+
+.draft-card span,
+.draft-card p {
+  margin: 0;
+  color: var(--ac-muted);
+  font-size: 12px;
+}
+
+.draft-card .ac-button {
+  justify-self: start;
 }
 
 .settings-pane {
@@ -219,6 +269,21 @@ body {
   padding: 0 10px;
   color: var(--ac-text);
   background: var(--ac-surface);
+}
+
+.preset-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.preset-row button {
+  min-height: 34px;
+  border: 1px solid var(--ac-border);
+  border-radius: var(--ac-radius);
+  background: var(--ac-surface);
+  color: var(--ac-muted);
+  cursor: pointer;
 }
 
 .settings-pane p,
@@ -250,9 +315,9 @@ body {
 }
 
 .sync-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
-  justify-content: center;
   gap: 8px;
   color: var(--ac-muted);
   font-size: 12px;

--- a/docs/chrome-extension-local-smoke.md
+++ b/docs/chrome-extension-local-smoke.md
@@ -16,7 +16,9 @@ This checklist is for issue #30: local unpacked Chrome extension install and bou
 - Required permissions: `sidePanel`, `scripting`, `storage`, `tabs`, `contextMenus`, `identity`
 - Host permissions: `<all_urls>`
 
-The extension API base defaults to `http://localhost:8787` through `DEFAULT_API_BASE` in `apps/extension/src/sidepanel/api.ts`. Testers can switch the API target in the side panel Settings tab; the value is persisted in `chrome.storage.local` under `apiBaseUrl`.
+The extension API base defaults to `http://localhost:8787` through `DEFAULT_API_BASE` in `apps/extension/src/sidepanel/api.ts`. Testers can switch the API target in the side panel Settings tab with the `Local` and `Production` presets or by typing a URL; the value is persisted in `chrome.storage.local` under `apiBaseUrl`.
+
+Local smoke drafts are stored in `chrome.storage.local` under `captureDraft`. The context-menu selected-text handoff uses `pendingCapture` once and clears it after the side panel reads it, which avoids stale selections during repeated smoke runs.
 
 ## Local Install Steps
 
@@ -90,6 +92,8 @@ Expected response shape:
 - [x] Extension action opens the Chrome side panel.
 - [x] Settings tab shows `http://localhost:8787` by default.
 - [x] Settings tab saves the API URL in `chrome.storage.local`.
+- [x] Settings tab includes local and production API-base presets.
+- [x] Capture tab can save and restore the latest local draft from Chrome extension storage.
 - [ ] Settings tab saves `https://annotated-canvas-api.jaybhagat841.workers.dev`, survives side-panel close/reopen, and publishes to the production Worker without source edits.
 - [ ] On a text page, select text, right-click, choose `Annotate selected text`, and confirm the side panel displays the selected text path.
 - [x] On a normal page, confirm the side panel reads the active tab URL/title through the content-script/tab fallback path.
@@ -98,6 +102,25 @@ Expected response shape:
 - [x] Verify the created annotation appears in the API feed or web client.
 - [ ] Enter a range over 90 seconds and confirm publish is blocked with `Clip length must be 90 seconds or less.` before the network publish.
 - [ ] Record a voice note, handle the microphone prompt, and publish it if the local API upload path is available; otherwise record the exact blocker.
+
+## Automated Extension Coverage
+
+Run before the browser proof:
+
+```sh
+npm run test:node -- apps/extension/src/sidepanel/api.test.ts
+npm run build:extension
+```
+
+Covered cases:
+
+- p50 media publish preserves the exact entered start/end/duration.
+- p95 media ranges over 90 seconds throw `range_too_long` before annotation fetch.
+- p95 audio commentary with a range over 90 seconds throws before upload or annotation fetch.
+- p95 selected-text publish trims and preserves the exact quote in `clip.text.quote` and uses `client_context.capture_method: "selection"`.
+- Production API-base persistence normalizes `https://annotated-canvas-api.jaybhagat841.workers.dev/` to `https://annotated-canvas-api.jaybhagat841.workers.dev`.
+- Pending selected-text capture clears after one read.
+- Local capture drafts persist with trimmed commentary.
 
 ## Verified Local Browser Evidence
 
@@ -127,6 +150,18 @@ Run this sequence after rebuilding and reloading `dist/extension`. Keep Chrome D
 
 Evidence to retain: build output, extension-card screenshot or recording, Settings screenshot before and after save, reopened Settings screenshot, the health-check response, and confirmation that no app or API source files were edited for the API-base switch.
 
+Template:
+
+```md
+API base saved:
+- Before:
+- After save:
+- After side-panel reopen:
+- Health command:
+- Health response:
+- Source edits required: no
+```
+
 ### p50 Happy Path
 
 1. Open a normal source page in Chrome.
@@ -136,6 +171,18 @@ Evidence to retain: build output, extension-card screenshot or recording, Settin
 5. Fetch the returned annotation or `GET https://annotated-canvas-api.jaybhagat841.workers.dev/api/feed` and confirm the new id appears.
 
 Evidence to retain: side-panel source screenshot, Network `POST /api/annotations` request to the production Worker, request JSON with `client_context.surface: "extension"`, response annotation id, feed/permalink/API proof for that id, and the exact commentary string used for correlation.
+
+Template:
+
+```md
+p50 publish:
+- Page URL/title:
+- Commentary:
+- Request URL:
+- Request client_context:
+- Response annotation id:
+- Feed/permalink/API proof:
+```
 
 ### p95 Selected-Text Context Menu
 
@@ -164,6 +211,20 @@ Evidence to retain: screenshot or recording of the selected browser text, the co
 
 Also retain the response annotation id and a follow-up API/permalink/feed response proving the stored annotation still contains the same quote and source URL.
 
+Template:
+
+```md
+Selected-text proof:
+- Page URL/title:
+- Exact selected text:
+- Side-panel quote preview:
+- Request clip.kind:
+- Request clip.text.quote:
+- Request capture_method:
+- Response annotation id:
+- Stored annotation proof:
+```
+
 ### p95 Real Media Current-Time Capture
 
 1. Open a page with a real top-level `<video>` or `<audio>` element. Avoid iframe-only players for this proof unless the extension explicitly supports reading them.
@@ -180,6 +241,19 @@ Also retain the response annotation id and a follow-up API/permalink/feed respon
 
 Evidence to retain: media page URL/title, media control or console proof of `currentTime`, side-panel `Start` and `End` fields, production `POST /api/annotations` payload showing `clip.kind` as `video` or `audio`, and exact `media.start_seconds`, `media.end_seconds`, and `media.duration_seconds`. Confirm the stored annotation through API/feed/permalink evidence.
 
+Template:
+
+```md
+Media timecode proof:
+- Page URL/title:
+- Console currentTime/tagName:
+- Side-panel Start/End:
+- Request clip.kind:
+- Request media:
+- Response annotation id:
+- Stored annotation proof:
+```
+
 ### p95 Over-90-Second Rejection
 
 1. Keep the production Worker URL saved in Settings.
@@ -190,6 +264,17 @@ Evidence to retain: media page URL/title, media control or console proof of `cur
 6. Confirm no new `POST /api/annotations` request was sent after the click.
 
 Evidence to retain: side-panel fields, the exact error text, a Network panel screenshot or HAR showing no production `POST /api/annotations` for the rejected click, and a note that API/contract validation still rejects over-90 payloads if sent directly.
+
+Template:
+
+```md
+Over-90 rejection:
+- Start:
+- End:
+- Error text:
+- Network proof of no POST:
+- API/contract validation note:
+```
 
 ### p95 Audio/R2 Limitation
 
@@ -207,6 +292,17 @@ Evidence to retain: side-panel fields, the exact error text, a Network panel scr
    ```
 
 Evidence to retain: microphone prompt or blocker screenshot, `Voice note ready` screenshot if recording succeeds, upload response JSON showing `upload.storage: "r2"` and `upload.status: "intent-created"` rather than `"stored"`, and a submission note that production omits `MEDIA_BUCKET` until #26 enables R2 or another durable audio storage path.
+
+Template:
+
+```md
+Audio limitation:
+- Microphone prompt/result:
+- Voice note ready:
+- Upload response:
+- Durable storage status:
+- Blocker owner:
+```
 
 ## Evidence To Capture
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -79,12 +79,12 @@ The MVP is not installed from the Chrome Web Store. Build the extension and load
 
 The extension side panel has four tabs:
 
-- `CONTEXT`: capture a source-linked text or timecode clip and add commentary.
-- `DRAFTS`: placeholder for saved draft annotations.
-- `ANNOTATIONS`: placeholder for previously published annotations.
-- `SETTINGS`: placeholder for account and provider settings.
+- `Capture`: capture a source-linked selected-text or timecode clip, add commentary, save a local draft, or publish.
+- `Drafts`: restore the most recent local smoke-test draft saved in Chrome extension storage.
+- `Published`: points reviewers to the API feed after publish.
+- `Settings`: switch the API base between localhost and the production Worker without source edits.
 
-The current side panel reads the active tab when it can, falls back to the demo source when it cannot, and publishes through the local API when `Publish annotation` is clicked. Use the API flow below when you need to inspect the exact backend payload.
+The side panel reads the active tab when it can, falls back to the tab URL/title when a content script cannot answer, and publishes through the configured API when `Publish annotation` is clicked. The Settings tab defaults to `http://localhost:8787` and includes a `Production` preset for `https://annotated-canvas-api.jaybhagat841.workers.dev`.
 
 When rebuilding the extension, return to `chrome://extensions` and click the reload icon on the Annotated Canvas card.
 
@@ -92,16 +92,18 @@ When rebuilding the extension, return to `chrome://extensions` and click the rel
 
 There are two MVP paths.
 
-### Publish from the Extension Demo
+### Publish from the Extension
 
 1. Load the unpacked extension from `dist/extension`.
-2. Open the extension side panel.
-3. On `Capture`, choose `Time range` or `Selected text`.
-4. Add commentary.
-5. Click `Publish annotation`.
-6. The button changes from `Publishing...` to `Published`.
+2. Start the local API with `npm run dev:api`, or open Settings and save the production Worker URL.
+3. Open the extension side panel on a real page.
+4. On `Capture`, choose `Time range` or `Selected text`.
+5. Add commentary.
+6. Optionally click `Save draft`; the latest local draft can be restored from `Drafts`.
+7. Click `Publish annotation`.
+8. The button changes from `Publishing...` to `Published`.
 
-This verifies the local capture UI, but it does not currently persist the annotation through the API.
+This posts to `POST /api/annotations` on the configured API base. For media clips, ranges longer than 90 seconds are blocked in the side panel before a network publish request is sent. For selected text, the context-menu path is `right-click selected text -> Annotate selected text`, then publish from the side panel.
 
 ### Publish Through the Local API
 
@@ -242,6 +244,8 @@ curl "http://localhost:8787/api/auth/x/start?return_to=http://127.0.0.1:5173/"
 ```
 
 In demo mode, the API returns an authorization URL that points directly to the local callback instead of redirecting to a real provider.
+
+The extension currently shows a signed-out limitation message because real extension OAuth handoff is not complete. Publishing still works against the API using the server-side demo author until the auth branch lands real provider credentials and token handoff.
 
 ## Troubleshooting
 

--- a/output/reports/gas-town/issue-23-30-extension-smoke-comments.md
+++ b/output/reports/gas-town/issue-23-30-extension-smoke-comments.md
@@ -1,0 +1,53 @@
+# Issue #23/#30 Extension Smoke Comment Drafts
+
+Prepared on May 1, 2026 from branch `codex/issue-23-extension-mvp-smoke`.
+
+Posted:
+
+- #30: https://github.com/ChaiWithJai/annotated-canvas/issues/30#issuecomment-4357699541
+- #23: https://github.com/ChaiWithJai/annotated-canvas/issues/23#issuecomment-4357699827
+
+## Issue #30 Comment Draft
+
+```md
+Extension local-install smoke update for #30:
+
+Implemented local-run affordances for the unpacked MV3 extension:
+- Settings now has explicit Local and Production API-base presets and still persists the normalized URL in `chrome.storage.local`.
+- Capture can save/restore the latest local draft from extension storage.
+- Context-menu selected-text handoff trims the selected quote and clears the pending capture after the side panel reads it.
+- Publish now has an explicit <=90s media guard before upload or annotation fetch, so over-limit audio/video attempts produce no publish network request.
+- The side panel now states the signed-out limitation: production publishes still use the demo API author until extension OAuth handoff lands.
+
+Automated evidence:
+- `npm run test:node -- apps/extension/src/sidepanel/api.test.ts`
+- `npm run build:extension`
+
+Acceptance criteria still requiring browser evidence:
+- Load `dist/extension` in Chrome 116+ from `chrome://extensions`.
+- Save `https://annotated-canvas-api.jaybhagat841.workers.dev` in Settings, close/reopen the side panel, and confirm it persists.
+- Publish one <=90s annotation to the production Worker and verify the returned annotation through feed/permalink/API.
+- Select exact text on a normal page, use `Annotate selected text`, publish, and verify `clip.text.quote` and `client_context.capture_method: "selection"`.
+- Capture a real top-level `<video>` or `<audio>` current time and verify seeded Start/End and production media payload.
+- Enter >90s, click publish, confirm `Clip length must be 90 seconds or less.` and no production `POST /api/annotations`.
+- Record the audio commentary outcome; production upload is expected to remain an `intent-created`/durable-storage limitation until #26.
+
+Docs updated with exact steps and evidence templates in `docs/chrome-extension-local-smoke.md` and `docs/user-guide.md`.
+```
+
+## Issue #23 Comment Draft
+
+```md
+Extension capture journey update for #23:
+
+The extension path is now closer to a repeatable end-to-end MVP smoke:
+- API base can be switched between localhost and production from the side panel without rebuild/source edits.
+- Selected-text capture is preserved from context menu to publish payload and stale pending captures are cleared.
+- Media publish blocks >90s ranges before any upload or annotation request.
+- Local draft save/restore exists for commentary/capture setup.
+- Signed-out/auth limitation is visible in the extension: publishing works through the API demo author while real extension OAuth handoff remains pending.
+
+Unit coverage now exercises p50 media publish, p95 selected-text payload, production API-base persistence, pending-capture clearing, local draft persistence, and >90s pre-network rejection.
+
+Remaining close gate is browser evidence against the production Worker: exact selected quote in the production payload/stored annotation, exact media seconds from a real `<video>`/`<audio>`, and over-90s rejection with no network publish.
+```


### PR DESCRIPTION
## Summary
- Add production/local API presets and normalized persisted API base for the unpacked extension
- Add local capture draft restore, stale pending-capture clearing, and clearer signed-out/auth limitation copy
- Block >90s media ranges before annotation/audio network calls and expand p50/p95 extension tests
- Update extension smoke/user docs and issue evidence templates

## Issues
Refs #23, #30, #26, #24

## Verification
- npm run test:node -- apps/extension/src/sidepanel/api.test.ts
- npm run build:extension
- npm run typecheck
- npm test

## Remaining blockers
Browser-level Chrome evidence still needs to be captured manually from `dist/extension`; real OAuth handoff remains in #24 and durable audio storage remains in #26.