### PR TITLE
feat(api): complete OAuth callback handoff

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment node
 import { fixtures } from "@annotated/contracts";
 import { beforeEach, describe, expect, it } from "vitest";
-import { handleRequest } from "./app";
+import { buildProviderAuthorizationUrl, createOAuthCodeChallenge, handleRequest } from "./app";
 import { InMemoryRepository } from "./repository";
 import { RecordingJobQueue } from "./queue";
-import type { Env } from "./types";
+import type { Env, OAuthProviderClient, OAuthProviderProfile, OAuthProviderTokens } from "./types";
 
 const env: Env = {
   APP_ORIGIN: "http://localhost:5173",
@@ -36,6 +36,107 @@ function createSessionKv(seed: Record<string, string> = {}) {
   return Object.assign(kv, { store }) as unknown as KVNamespace & { store: Map<string, string> };
 }
 
+function createAuthDb() {
+  const users = new Map<string, any>();
+  const oauthAccounts = new Map<string, any>();
+  const sessions = new Map<string, any>();
+
+  const db = {
+    users,
+    oauthAccounts,
+    sessions,
+    prepare(sql: string) {
+      let bindings: any[] = [];
+      return {
+        bind(...values: any[]) {
+          bindings = values;
+          return this;
+        },
+        async first() {
+          if (sql.includes("FROM oauth_accounts")) {
+            const [provider, providerAccountId] = bindings;
+            const account = Array.from(oauthAccounts.values()).find(
+              (item) => item.provider === provider && item.provider_account_id === providerAccountId
+            );
+            if (!account) return null;
+            return users.get(account.user_id) ?? null;
+          }
+
+          if (sql.includes("SELECT id FROM users WHERE handle = ?")) {
+            const [handle] = bindings;
+            return Array.from(users.values()).find((item) => item.handle === handle) ?? null;
+          }
+
+          return null;
+        },
+        async run() {
+          if (sql.startsWith("INSERT INTO users")) {
+            const [id, handle, displayName, avatarUrl, bio] = bindings;
+            users.set(id, {
+              id,
+              handle,
+              display_name: displayName,
+              avatar_url: avatarUrl,
+              bio
+            });
+          } else if (sql.startsWith("UPDATE users SET")) {
+            const [handle, displayName, avatarUrl, bio, id] = bindings;
+            const existing = users.get(id);
+            users.set(id, {
+              ...existing,
+              id,
+              handle,
+              display_name: displayName,
+              avatar_url: avatarUrl,
+              bio
+            });
+          } else if (sql.startsWith("INSERT INTO oauth_accounts")) {
+            const [id, userId, provider, providerAccountId] = bindings;
+            oauthAccounts.set(id, {
+              id,
+              user_id: userId,
+              provider,
+              provider_account_id: providerAccountId
+            });
+          } else if (sql.startsWith("INSERT OR REPLACE INTO sessions")) {
+            const [id, userId, expiresAt] = bindings;
+            sessions.set(id, {
+              id,
+              user_id: userId,
+              expires_at: expiresAt
+            });
+          } else if (sql.startsWith("DELETE FROM sessions")) {
+            sessions.delete(bindings[0]);
+          }
+          return { success: true };
+        }
+      };
+    }
+  };
+
+  return db as unknown as D1Database & {
+    users: Map<string, any>;
+    oauthAccounts: Map<string, any>;
+    sessions: Map<string, any>;
+  };
+}
+
+function createOAuthClient(profile: OAuthProviderProfile, tokens: OAuthProviderTokens = { access_token: "provider-token" }) {
+  const calls: Array<{ type: "exchange"; input: any } | { type: "profile"; provider: string; tokens: OAuthProviderTokens }> = [];
+  const client: OAuthProviderClient & { calls: typeof calls } = {
+    calls,
+    async exchangeCode(input) {
+      calls.push({ type: "exchange", input });
+      return tokens;
+    },
+    async fetchProfile(provider, fetchedTokens) {
+      calls.push({ type: "profile", provider, tokens: fetchedTokens });
+      return profile;
+    }
+  };
+  return client;
+}
+
 describe("API router regression coverage", () => {
   let repository: InMemoryRepository;
   let jobs: RecordingJobQueue;
@@ -51,6 +152,35 @@ describe("API router regression coverage", () => {
 
     expect(health.status).toBe(200);
     expect((await body(feed)).items).toHaveLength(3);
+  });
+
+  it("builds provider authorization URLs with PKCE and provider scopes", async () => {
+    const challenge = await createOAuthCodeChallenge("test-verifier");
+    const googleUrl = new URL(
+      buildProviderAuthorizationUrl(
+        "google",
+        "google-client",
+        "https://api.annotated.test/api/auth/google/callback?state=state_1&return_to=http%3A%2F%2Flocalhost%3A5173%2F",
+        "state_1",
+        challenge
+      )
+    );
+    const xUrl = new URL(
+      buildProviderAuthorizationUrl(
+        "x",
+        "x-client",
+        "https://api.annotated.test/api/auth/x/callback?state=state_2&return_to=http%3A%2F%2Flocalhost%3A5173%2F",
+        "state_2",
+        challenge
+      )
+    );
+
+    expect(googleUrl.origin).toBe("https://accounts.google.com");
+    expect(googleUrl.searchParams.get("scope")).toBe("openid email profile");
+    expect(googleUrl.searchParams.get("code_challenge")).toBe(challenge);
+    expect(googleUrl.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(xUrl.origin).toBe("https://twitter.com");
+    expect(xUrl.searchParams.get("scope")).toBe("users.read tweet.read");
   });
 
   it("serves p50 auth start, callback, and extension-token routes", async () => {
@@ -115,20 +245,30 @@ describe("API router regression coverage", () => {
     expect(missingKvPayload.authorization_url).toBeUndefined();
   });
 
-  it("validates and consumes oauth callback state before returning not implemented", async () => {
+  it("validates state, exchanges provider code, persists local user and session, and rejects replay", async () => {
     const sessionKv = createSessionKv();
+    const db = createAuthDb();
+    const oauth = createOAuthClient({
+      provider: "google",
+      provider_account_id: "google-user-123",
+      handle: "mira.oauth",
+      display_name: "Mira OAuth",
+      avatar_url: "https://profiles.example/mira.png"
+    });
     const oauthEnv: Env = {
       ...env,
       AUTH_MODE: "oauth",
       GOOGLE_CLIENT_ID: "google-client",
       GOOGLE_CLIENT_SECRET: "google-secret",
-      SESSION_KV: sessionKv
+      SESSION_KV: sessionKv,
+      DB: db
     };
 
     const start = await body(
       await handleRequest(request("/api/auth/google/start?return_to=/after-auth"), oauthEnv, { repository, jobs })
     );
     expect(start.authorization_url).toContain("accounts.google.com");
+    expect(start.authorization_url).toContain("code_challenge=");
     expect(sessionKv.store.has(`oauth_state:${start.state}`)).toBe(true);
 
     const missingCode = await handleRequest(request(`/api/auth/google/callback?state=${start.state}`), oauthEnv, {
@@ -149,19 +289,108 @@ describe("API router regression coverage", () => {
     const firstCallback = await handleRequest(
       request(`/api/auth/google/callback?state=${start.state}&code=auth-code`),
       oauthEnv,
+      { repository, jobs, oauth }
+    );
+    expect(firstCallback.status).toBe(302);
+    expect(firstCallback.headers.get("Location")).toBe("http://localhost:5173/after-auth");
+    expect(firstCallback.headers.get("Set-Cookie")).toContain("annotated_session=");
+    expect(sessionKv.store.has(`oauth_state:${start.state}`)).toBe(false);
+    expect(db.users.size).toBe(1);
+    expect(db.oauthAccounts.size).toBe(1);
+    expect(db.sessions.size).toBe(1);
+
+    const exchangeCall = oauth.calls.find(
+      (call): call is { type: "exchange"; input: any } => call.type === "exchange"
+    );
+    expect(exchangeCall?.input).toMatchObject({
+      provider: "google",
+      code: "auth-code",
+      client_id: "google-client",
+      client_secret: "google-secret"
+    });
+    expect(exchangeCall?.input.redirect_uri).toBe("https://api.annotated.test/api/auth/google/callback");
+    expect(exchangeCall?.input.code_verifier).toEqual(expect.any(String));
+
+    const sessionId = firstCallback.headers.get("Set-Cookie")?.match(/annotated_session=([^;]+)/)?.[1];
+    expect(sessionId).toBeTruthy();
+    const me = await handleRequest(
+      request("/api/me", {
+        headers: {
+          Cookie: `annotated_session=${sessionId}`
+        }
+      }),
+      oauthEnv,
       { repository, jobs }
     );
-    expect(firstCallback.status).toBe(501);
-    expect((await body(firstCallback)).error.code).toBe("not_implemented");
-    expect(sessionKv.store.has(`oauth_state:${start.state}`)).toBe(false);
+    expect(me.status).toBe(200);
+    expect((await body(me)).user).toMatchObject({
+      handle: "mira_oauth",
+      display_name: "Mira OAuth"
+    });
 
     const replayedCallback = await handleRequest(
       request(`/api/auth/google/callback?state=${start.state}&code=auth-code`),
       oauthEnv,
-      { repository, jobs }
+      { repository, jobs, oauth }
     );
     expect(replayedCallback.status).toBe(400);
     expect((await body(replayedCallback)).error.code).toBe("invalid_oauth_state");
+  });
+
+  it("fails oauth callback closed for missing config without consuming state", async () => {
+    const sessionKv = createSessionKv({
+      "oauth_state:state_missing_secret": JSON.stringify({
+        provider: "x",
+        return_to: "http://localhost:5173/"
+      })
+    });
+    const response = await handleRequest(
+      request("/api/auth/x/callback?state=state_missing_secret&code=auth-code"),
+      {
+        ...env,
+        AUTH_MODE: "oauth",
+        X_CLIENT_ID: "x-client",
+        SESSION_KV: sessionKv
+      },
+      { repository, jobs }
+    );
+
+    expect(response.status).toBe(503);
+    expect((await body(response)).error.code).toBe("auth_not_configured");
+    expect(sessionKv.store.has("oauth_state:state_missing_secret")).toBe(true);
+  });
+
+  it("consumes valid state and reports provider failures without creating a session", async () => {
+    const sessionKv = createSessionKv();
+    const oauthEnv: Env = {
+      ...env,
+      AUTH_MODE: "oauth",
+      X_CLIENT_ID: "x-client",
+      X_CLIENT_SECRET: "x-secret",
+      SESSION_KV: sessionKv,
+      DB: createAuthDb()
+    };
+    const failingOAuth: OAuthProviderClient = {
+      async exchangeCode() {
+        throw new Error("provider_unavailable");
+      },
+      async fetchProfile() {
+        throw new Error("unreachable");
+      }
+    };
+
+    const start = await body(await handleRequest(request("/api/auth/x/start?return_to=/"), oauthEnv, { repository, jobs }));
+    const response = await handleRequest(
+      request(`/api/auth/x/callback?state=${start.state}&code=auth-code`),
+      oauthEnv,
+      { repository, jobs, oauth: failingOAuth }
+    );
+    const payload = await body(response);
+
+    expect(response.status).toBe(502);
+    expect(payload.error.code).toBe("oauth_provider_error");
+    expect(sessionKv.store.has(`oauth_state:${start.state}`)).toBe(false);
+    expect(Array.from(sessionKv.store.keys()).some((key) => key.startsWith("session:"))).toBe(false);
   });
 
   it("requires a valid oauth session for me and extension-token", async () => {
@@ -222,7 +451,9 @@ describe("API router regression coverage", () => {
       { repository, jobs }
     );
     expect(token.status).toBe(200);
-    expect((await body(token)).token_type).toBe("Bearer");
+    const tokenPayload = await body(token);
+    expect(tokenPayload.token_type).toBe("Bearer");
+    expect(sessionKv.store.has(`extension_token:${tokenPayload.token}`)).toBe(true);
   });
 
   it("deletes the session on logout when session KV is available", async () => {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -11,18 +11,27 @@ import {
 } from "@annotated/contracts";
 import { D1Repository, InMemoryRepository, normalizeAppOrigin } from "./repository";
 import { CloudflareJobQueue } from "./queue";
-import type { Env, JobQueue, QueueJob, Repository } from "./types";
+import type {
+  AuthProvider,
+  Env,
+  JobQueue,
+  OAuthProviderClient,
+  OAuthProviderProfile,
+  OAuthProviderTokens,
+  QueueJob,
+  Repository
+} from "./types";
 
 interface Services {
   repository: Repository;
   jobs: JobQueue;
+  oauth?: OAuthProviderClient;
 }
-
-type AuthProvider = "x" | "google";
 
 interface OAuthState {
   provider: AuthProvider;
   return_to: string;
+  code_verifier?: string;
 }
 
 interface AuthSession {
@@ -30,6 +39,7 @@ interface AuthSession {
   provider?: AuthProvider;
   handle?: string;
   display_name?: string;
+  avatar_url?: string;
 }
 
 const DEMO_USER = {
@@ -53,7 +63,8 @@ export function makeServices(env: Env): Services {
   const appOrigin = normalizeAppOrigin(env.APP_ORIGIN);
   return {
     repository: env.DB ? new D1Repository(env.DB, appOrigin) : getDefaultRepository(appOrigin),
-    jobs: new CloudflareJobQueue(env)
+    jobs: new CloudflareJobQueue(env),
+    oauth: new FetchOAuthProviderClient()
   };
 }
 
@@ -205,7 +216,8 @@ function parseOAuthState(value: string): OAuthState | null {
     ) {
       return {
         provider: parsed.provider,
-        return_to: parsed.return_to
+        return_to: parsed.return_to,
+        code_verifier: typeof parsed.code_verifier === "string" ? parsed.code_verifier : undefined
       };
     }
   } catch {
@@ -226,7 +238,8 @@ function parseAuthSession(value: string): AuthSession | null {
       user_id: parsed.user_id,
       provider: parsed.provider === "x" || parsed.provider === "google" ? parsed.provider : undefined,
       handle: typeof parsed.handle === "string" ? parsed.handle : undefined,
-      display_name: typeof parsed.display_name === "string" ? parsed.display_name : undefined
+      display_name: typeof parsed.display_name === "string" ? parsed.display_name : undefined,
+      avatar_url: typeof parsed.avatar_url === "string" ? parsed.avatar_url : undefined
     };
   } catch {
     return null;
@@ -284,8 +297,160 @@ function userFromSession(session: AuthSession) {
   return {
     id: session.user_id,
     handle: session.handle ?? DEMO_USER.handle,
-    display_name: session.display_name ?? DEMO_USER.display_name
+    display_name: session.display_name ?? DEMO_USER.display_name,
+    avatar_url: session.avatar_url
   };
+}
+
+function base64Url(bytes: ArrayBuffer): string {
+  const binary = Array.from(new Uint8Array(bytes), (byte) => String.fromCharCode(byte)).join("");
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+export function createOAuthCodeVerifier(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return base64Url(bytes.buffer);
+}
+
+export async function createOAuthCodeChallenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  return base64Url(digest);
+}
+
+function normalizeHandle(value: string | undefined, fallback: string): string {
+  const normalized = (value ?? fallback)
+    .toLowerCase()
+    .replace(/^@/, "")
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 24);
+
+  return normalized.length > 0 ? normalized : fallback;
+}
+
+function sessionFromUser(user: PersistedOAuthUser, provider: AuthProvider): AuthSession {
+  return {
+    user_id: user.id,
+    provider,
+    handle: user.handle,
+    display_name: user.display_name,
+    avatar_url: user.avatar_url
+  };
+}
+
+type PersistedOAuthUser = {
+  id: string;
+  handle: string;
+  display_name: string;
+  avatar_url?: string;
+};
+
+async function findUniqueHandle(db: D1Database, desiredHandle: string, userId?: string): Promise<string> {
+  const baseHandle = normalizeHandle(desiredHandle, "annotated_user");
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const candidate = attempt === 0 ? baseHandle : `${baseHandle.slice(0, 18)}_${attempt + 1}`;
+    const row = await db.prepare("SELECT id FROM users WHERE handle = ?").bind(candidate).first<{ id: string }>();
+    if (!row || row.id === userId) return candidate;
+  }
+
+  return `${baseHandle.slice(0, 16)}_${crypto.randomUUID().slice(0, 8)}`;
+}
+
+async function upsertOAuthUser(env: Env, profile: OAuthProviderProfile): Promise<PersistedOAuthUser> {
+  const fallbackHandle = `${profile.provider}_${profile.provider_account_id}`;
+  if (!env.DB) {
+    return {
+      id: `usr_${profile.provider}_${profile.provider_account_id}`,
+      handle: normalizeHandle(profile.handle, fallbackHandle),
+      display_name: profile.display_name,
+      avatar_url: profile.avatar_url
+    };
+  }
+
+  const existing = await env.DB
+    .prepare(
+      `SELECT u.id, u.handle, u.display_name, u.avatar_url
+       FROM oauth_accounts oa
+       JOIN users u ON u.id = oa.user_id
+       WHERE oa.provider = ? AND oa.provider_account_id = ?`
+    )
+    .bind(profile.provider, profile.provider_account_id)
+    .first<{ id: string; handle: string; display_name: string; avatar_url: string | null }>();
+
+  if (existing) {
+    const handle = await findUniqueHandle(env.DB, normalizeHandle(profile.handle, existing.handle), existing.id);
+    await env.DB
+      .prepare("UPDATE users SET handle = ?, display_name = ?, avatar_url = ?, bio = ? WHERE id = ?")
+      .bind(handle, profile.display_name, profile.avatar_url ?? null, profile.bio ?? null, existing.id)
+      .run();
+    return {
+      id: existing.id,
+      handle,
+      display_name: profile.display_name,
+      avatar_url: profile.avatar_url
+    };
+  }
+
+  const userId = `usr_${crypto.randomUUID()}`;
+  const handle = await findUniqueHandle(env.DB, normalizeHandle(profile.handle, fallbackHandle));
+  await env.DB
+    .prepare("INSERT INTO users (id, handle, display_name, avatar_url, bio) VALUES (?, ?, ?, ?, ?)")
+    .bind(userId, handle, profile.display_name, profile.avatar_url ?? null, profile.bio ?? null)
+    .run();
+  await env.DB
+    .prepare("INSERT INTO oauth_accounts (id, user_id, provider, provider_account_id) VALUES (?, ?, ?, ?)")
+    .bind(`oauth_${crypto.randomUUID()}`, userId, profile.provider, profile.provider_account_id)
+    .run();
+
+  return {
+    id: userId,
+    handle,
+    display_name: profile.display_name,
+    avatar_url: profile.avatar_url
+  };
+}
+
+async function persistSession(env: Env, sessionId: string, session: AuthSession, ttlSeconds: number): Promise<void> {
+  if (!env.SESSION_KV) throw new Error("session_kv_required");
+
+  await env.SESSION_KV.put(`session:${sessionId}`, JSON.stringify(session), { expirationTtl: ttlSeconds });
+
+  if (env.DB) {
+    const expiresAt = new Date(Date.now() + ttlSeconds * 1000).toISOString();
+    await env.DB
+      .prepare("INSERT OR REPLACE INTO sessions (id, user_id, expires_at) VALUES (?, ?, ?)")
+      .bind(sessionId, session.user_id, expiresAt)
+      .run();
+  }
+}
+
+async function deleteSession(env: Env, sessionId: string): Promise<void> {
+  if (env.SESSION_KV) {
+    await env.SESSION_KV.delete(`session:${sessionId}`);
+  }
+  if (env.DB) {
+    await env.DB.prepare("DELETE FROM sessions WHERE id = ?").bind(sessionId).run();
+  }
+}
+
+async function storeExtensionToken(env: Env, session: AuthSession): Promise<{ token: string; expires_in: number }> {
+  const token = `ext_${crypto.randomUUID()}`;
+  const expiresIn = 3600;
+  if (env.SESSION_KV) {
+    await env.SESSION_KV.put(
+      `extension_token:${token}`,
+      JSON.stringify({
+        user_id: session.user_id,
+        provider: session.provider,
+        handle: session.handle,
+        display_name: session.display_name
+      }),
+      { expirationTtl: expiresIn }
+    );
+  }
+
+  return { token, expires_in: expiresIn };
 }
 
 export async function handleRequest(request: Request, env: Env, services = makeServices(env)): Promise<Response> {
@@ -343,21 +508,25 @@ export async function handleRequest(request: Request, env: Env, services = makeS
     }
 
     const callbackUrl = new URL(`/api/auth/${provider.data}/callback`, url.origin);
-    callbackUrl.searchParams.set("state", state);
-    callbackUrl.searchParams.set("return_to", returnTo);
-    if (mode === "demo") callbackUrl.searchParams.set("code", "demo");
+    if (mode === "demo") {
+      callbackUrl.searchParams.set("state", state);
+      callbackUrl.searchParams.set("return_to", returnTo);
+      callbackUrl.searchParams.set("code", "demo");
+    }
+    const codeVerifier = mode === "oauth" ? createOAuthCodeVerifier() : undefined;
+    const codeChallenge = codeVerifier ? await createOAuthCodeChallenge(codeVerifier) : undefined;
 
     if (env.SESSION_KV) {
       await env.SESSION_KV.put(
         `oauth_state:${state}`,
-        JSON.stringify({ provider: provider.data, return_to: returnTo }),
+        JSON.stringify({ provider: provider.data, return_to: returnTo, code_verifier: codeVerifier }),
         { expirationTtl: 600 }
       );
     }
 
     const authorizationUrl =
       mode === "oauth" && credentials.clientId
-        ? buildProviderAuthorizationUrl(provider.data, credentials.clientId, callbackUrl.toString(), state)
+        ? buildProviderAuthorizationUrl(provider.data, credentials.clientId, callbackUrl.toString(), state, codeChallenge)
         : callbackUrl.toString();
 
     return json(env, {
@@ -387,6 +556,11 @@ export async function handleRequest(request: Request, env: Env, services = makeS
         return error(env, 400, "oauth_code_required", "OAuth callback requires code.");
       }
 
+      const missing = missingOAuthConfig(env, provider.data);
+      if (missing.length > 0) {
+        return oauthConfigError(env, request, provider.data, missing);
+      }
+
       if (!env.SESSION_KV) {
         return error(env, 503, "auth_not_configured", "OAuth state validation requires SESSION_KV.");
       }
@@ -403,23 +577,55 @@ export async function handleRequest(request: Request, env: Env, services = makeS
         return error(env, 400, "invalid_oauth_state", "OAuth state is invalid or has already been used.");
       }
 
-      return error(env, 501, "not_implemented", "OAuth token exchange is not implemented.", {
-        provider: provider.data
-      });
+      const callbackUrl = new URL(`/api/auth/${provider.data}/callback`, url.origin);
+
+      const credentials = getProviderCredentials(env, provider.data);
+      const oauth = services.oauth ?? new FetchOAuthProviderClient();
+      let profile: OAuthProviderProfile;
+      try {
+        const tokens = await oauth.exchangeCode({
+          provider: provider.data,
+          code,
+          redirect_uri: callbackUrl.toString(),
+          client_id: credentials.clientId ?? "",
+          client_secret: credentials.clientSecret ?? "",
+          code_verifier: storedState.code_verifier
+        });
+        profile = await oauth.fetchProfile(provider.data, tokens);
+      } catch (caught) {
+        return providerAuthError(env, request, provider.data, caught);
+      }
+
+      try {
+        const user = await upsertOAuthUser(env, profile);
+        const sessionId = `ses_${crypto.randomUUID()}`;
+        const session = sessionFromUser(user, provider.data);
+        await persistSession(env, sessionId, session, 60 * 60 * 24 * 14);
+
+        return new Response(null, {
+          status: 302,
+          headers: {
+            Location: storedState.return_to,
+            "Set-Cookie": sessionCookie("annotated_session", sessionId, env, 1209600),
+            ...corsHeaders(env, request)
+          }
+        });
+      } catch {
+        return error(env, 500, "oauth_session_failed", "OAuth session could not be created.", {
+          provider: provider.data
+        }, request);
+      }
     }
 
     const sessionId = `ses_${crypto.randomUUID()}`;
+    const session: AuthSession = {
+      user_id: DEMO_USER.id,
+      provider: provider.data,
+      handle: DEMO_USER.handle,
+      display_name: DEMO_USER.display_name
+    };
     if (env.SESSION_KV) {
-      await env.SESSION_KV.put(
-        `session:${sessionId}`,
-        JSON.stringify({
-          user_id: DEMO_USER.id,
-          provider: provider.data,
-          handle: DEMO_USER.handle,
-          display_name: DEMO_USER.display_name
-        }),
-        { expirationTtl: 60 * 60 * 24 * 14 }
-      );
+      await persistSession(env, sessionId, session, 60 * 60 * 24 * 14);
     }
 
     return new Response(null, {
@@ -433,22 +639,31 @@ export async function handleRequest(request: Request, env: Env, services = makeS
   }
 
   if (url.pathname === "/api/auth/extension-token" && request.method === "POST") {
+    let session: AuthSession = {
+      user_id: DEMO_USER.id,
+      provider: undefined,
+      handle: DEMO_USER.handle,
+      display_name: DEMO_USER.display_name
+    };
+
     if (authMode(env) === "oauth") {
-      const session = await requireOAuthSession(request, env);
-      if (session instanceof Response) return session;
+      const oauthSession = await requireOAuthSession(request, env);
+      if (oauthSession instanceof Response) return oauthSession;
+      session = oauthSession;
     }
 
+    const token = await storeExtensionToken(env, session);
     return json(env, {
-      token: `ext_${crypto.randomUUID()}`,
-      expires_in: 3600,
+      token: token.token,
+      expires_in: token.expires_in,
       token_type: "Bearer"
     });
   }
 
   if (url.pathname === "/api/auth/logout" && request.method === "POST") {
     const sessionId = parseCookie(request, "annotated_session");
-    if (env.SESSION_KV && sessionId) {
-      await env.SESSION_KV.delete(`session:${sessionId}`);
+    if (sessionId) {
+      await deleteSession(env, sessionId);
     }
 
     return json(
@@ -687,11 +902,12 @@ export async function handleRequest(request: Request, env: Env, services = makeS
   return error(env, 404, "route_not_found", "No route matches this request.");
 }
 
-function buildProviderAuthorizationUrl(
+export function buildProviderAuthorizationUrl(
   provider: "x" | "google",
   clientId: string,
   redirectUri: string,
-  state: string
+  state: string,
+  codeChallenge?: string
 ): string {
   const authorizationUrl =
     provider === "google"
@@ -702,5 +918,151 @@ function buildProviderAuthorizationUrl(
   authorizationUrl.searchParams.set("response_type", "code");
   authorizationUrl.searchParams.set("state", state);
   authorizationUrl.searchParams.set("scope", provider === "google" ? "openid email profile" : "users.read tweet.read");
+  if (codeChallenge) {
+    authorizationUrl.searchParams.set("code_challenge", codeChallenge);
+    authorizationUrl.searchParams.set("code_challenge_method", "S256");
+  }
   return authorizationUrl.toString();
+}
+
+class OAuthProviderError extends Error {
+  constructor(
+    message: string,
+    readonly stage: "token" | "profile",
+    readonly status?: number
+  ) {
+    super(message);
+  }
+}
+
+function providerAuthError(env: Env, request: Request, provider: AuthProvider, caught: unknown): Response {
+  if (caught instanceof OAuthProviderError) {
+    return error(env, 502, "oauth_provider_error", "OAuth provider request failed.", {
+      provider,
+      stage: caught.stage,
+      status: caught.status
+    }, request);
+  }
+
+  return error(env, 502, "oauth_provider_error", "OAuth provider request failed.", { provider }, request);
+}
+
+function requireString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function parseGoogleProfile(value: unknown): OAuthProviderProfile | null {
+  if (!isRecord(value)) return null;
+  const sub = requireString(value.sub);
+  const email = requireString(value.email);
+  const displayName = requireString(value.name) ?? email;
+  if (!sub || !displayName) return null;
+
+  return {
+    provider: "google",
+    provider_account_id: sub,
+    handle: email?.split("@")[0],
+    display_name: displayName,
+    avatar_url: requireString(value.picture) ?? undefined
+  };
+}
+
+function parseXProfile(value: unknown): OAuthProviderProfile | null {
+  if (!isRecord(value) || !isRecord(value.data)) return null;
+  const id = requireString(value.data.id);
+  const displayName = requireString(value.data.name) ?? requireString(value.data.username);
+  if (!id || !displayName) return null;
+
+  return {
+    provider: "x",
+    provider_account_id: id,
+    handle: requireString(value.data.username) ?? undefined,
+    display_name: displayName,
+    avatar_url: requireString(value.data.profile_image_url) ?? undefined,
+    bio: requireString(value.data.description) ?? undefined
+  };
+}
+
+async function parseJsonResponse(response: Response, stage: "token" | "profile"): Promise<unknown> {
+  if (!response.ok) {
+    throw new OAuthProviderError("provider_request_failed", stage, response.status);
+  }
+
+  try {
+    return await response.json();
+  } catch {
+    throw new OAuthProviderError("provider_invalid_json", stage, response.status);
+  }
+}
+
+class FetchOAuthProviderClient implements OAuthProviderClient {
+  async exchangeCode(input: {
+    provider: AuthProvider;
+    code: string;
+    redirect_uri: string;
+    client_id: string;
+    client_secret: string;
+    code_verifier?: string;
+  }): Promise<OAuthProviderTokens> {
+    const body = new URLSearchParams({
+      code: input.code,
+      grant_type: "authorization_code",
+      redirect_uri: input.redirect_uri
+    });
+
+    let response: Response;
+    if (input.provider === "google") {
+      body.set("client_id", input.client_id);
+      body.set("client_secret", input.client_secret);
+      if (input.code_verifier) body.set("code_verifier", input.code_verifier);
+      response = await fetch("https://oauth2.googleapis.com/token", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded"
+        },
+        body
+      });
+    } else {
+      if (input.code_verifier) body.set("code_verifier", input.code_verifier);
+      response = await fetch("https://api.twitter.com/2/oauth2/token", {
+        method: "POST",
+        headers: {
+          Authorization: `Basic ${btoa(`${input.client_id}:${input.client_secret}`)}`,
+          "Content-Type": "application/x-www-form-urlencoded"
+        },
+        body
+      });
+    }
+
+    const parsed = await parseJsonResponse(response, "token");
+    if (!isRecord(parsed) || typeof parsed.access_token !== "string" || parsed.access_token.length === 0) {
+      throw new OAuthProviderError("token_missing", "token", response.status);
+    }
+
+    return {
+      access_token: parsed.access_token,
+      token_type: typeof parsed.token_type === "string" ? parsed.token_type : undefined,
+      expires_in: typeof parsed.expires_in === "number" ? parsed.expires_in : undefined
+    };
+  }
+
+  async fetchProfile(provider: AuthProvider, tokens: OAuthProviderTokens): Promise<OAuthProviderProfile> {
+    const url =
+      provider === "google"
+        ? "https://openidconnect.googleapis.com/v1/userinfo"
+        : "https://api.twitter.com/2/users/me?user.fields=profile_image_url,description";
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${tokens.access_token}`
+      }
+    });
+
+    const parsed = await parseJsonResponse(response, "profile");
+    const profile = provider === "google" ? parseGoogleProfile(parsed) : parseXProfile(parsed);
+    if (!profile) {
+      throw new OAuthProviderError("profile_invalid", "profile", response.status);
+    }
+
+    return profile;
+  }
 }

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -18,6 +18,37 @@ export interface QueueJob {
   created_at: string;
 }
 
+export type AuthProvider = "x" | "google";
+
+export interface OAuthProviderTokens {
+  access_token: string;
+  token_type?: string;
+  expires_in?: number;
+}
+
+export interface OAuthProviderProfile {
+  provider: AuthProvider;
+  provider_account_id: string;
+  handle?: string;
+  display_name: string;
+  avatar_url?: string;
+  bio?: string;
+}
+
+export interface OAuthTokenExchangeInput {
+  provider: AuthProvider;
+  code: string;
+  redirect_uri: string;
+  client_id: string;
+  client_secret: string;
+  code_verifier?: string;
+}
+
+export interface OAuthProviderClient {
+  exchangeCode(input: OAuthTokenExchangeInput): Promise<OAuthProviderTokens>;
+  fetchProfile(provider: AuthProvider, tokens: OAuthProviderTokens): Promise<OAuthProviderProfile>;
+}
+
 export interface Env {
   APP_ORIGIN?: string;
   SERVICE_MODE?: string;

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -92,6 +92,8 @@ Validation rules:
 | `POST` | `/api/auth/logout` | Revoke current session. |
 | `GET` | `/api/me` | Return current user and auth capabilities. |
 
+In `AUTH_MODE=oauth`, provider callbacks exchange the authorization code with Google or X, fetch the provider profile, link it to `users`/`oauth_accounts`, and mint both a KV-backed browser session and D1 `sessions` row when D1 is bound. `POST /api/auth/extension-token` requires the browser session in OAuth mode and stores a one-hour KV handoff token under `extension_token:*`.
+
 ### Capture and Publish
 
 | Method | Path | Purpose |

--- a/docs/cloudflare-cli.md
+++ b/docs/cloudflare-cli.md
@@ -97,7 +97,7 @@ Auth and media gates are separate:
 - R2 bucket name, if enabled: `annotated-canvas-media`.
 - Worker binding to restore after storage exists: `MEDIA_BUCKET`.
 
-Do not install OAuth provider secrets until #24 has finalized the production secret names and token-exchange implementation. Do not restore the production R2 binding until R2 is enabled or an alternate storage path has been chosen.
+OAuth provider secret names are `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `X_CLIENT_ID`, and `X_CLIENT_SECRET`. Do not restore the production R2 binding until R2 is enabled or an alternate storage path has been chosen.
 
 Local OAuth is optional and mainly useful when an engineer wants an interactive fallback session:
 


### PR DESCRIPTION
## Summary
- Add Google and X OAuth token/profile exchange paths instead of returning `not_implemented` after state validation
- Create production OAuth sessions with fail-closed state replay, provider error, missing-secret, and cookie handling
- Add extension-token handoff coverage for authenticated OAuth sessions
- Document provider setup and API contract behavior

## Issues
Refs #24

## Verification
- npm run test:node -- apps/api/src/app.test.ts
- npm run typecheck
- npm test
- git diff --check

## Remaining blocker
Production OAuth still requires human provider setup: Google/X OAuth apps, callback URLs, and Cloudflare secrets for `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `X_CLIENT_ID`, and `X_CLIENT_SECRET`.