### PR TITLE
[codex] reconcile bounty submission readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ Annotated Canvas is a Chrome side panel and web client for clipping exact moment
 
 The product is based on the `Annotated` bounty context captured in this repository. The MVP intentionally stores third-party clips by reference, not by re-hosting third-party media bytes.
 
+## Submission Status
+
+- Public web: `https://annotated-canvas.pages.dev`
+- Public API health: `https://annotated-canvas-api.jaybhagat841.workers.dev/api/health`
+- Approved public smoke annotation: `https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`
+- Cloudflare deploy-from-main is proven by GitHub Actions run `25212955639`; issue #22 is closed.
+- The current MVP is live, source-linked, and smoke-tested at the API/web level. It is not yet a full bounty-complete claim.
+- Remaining bounty blockers are real Google/X OAuth and extension handoff (#24), production extension p95 proof for exact selected text/media timing and >90-second no-network rejection (#23/#30), durable recorded-audio storage and owned-media 240p/sub-480p policy (#26), and the final external submission decision (#28).
+
 ## Product Surfaces
 
 - Chrome MV3 side panel extension for capture from the current tab.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The product is based on the `Annotated` bounty context captured in this reposito
 - Approved public smoke annotation: `https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`
 - Cloudflare deploy-from-main is proven by GitHub Actions run `25212955639`; issue #22 is closed.
 - The current MVP is live, source-linked, and smoke-tested at the API/web level. It is not yet a full bounty-complete claim.
-- Remaining bounty blockers are real Google/X OAuth and extension handoff (#24), production extension p95 proof for exact selected text/media timing and >90-second no-network rejection (#23/#30), durable recorded-audio storage and owned-media 240p/sub-480p policy (#26), and the final external submission decision (#28).
+- Remaining bounty blockers are real Google/X OAuth and extension handoff (#24), production extension p95 proof for exact selected text/media timing and >90-second no-network rejection (#23/#30), durable recorded-audio storage and owned-media 240p/sub-480p policy (#26), the reviewer journey/Krug pass before filming (#38), and the final external submission decision (#28).
 
 ## Product Surfaces
 

--- a/docs/bounty-gap-audit.md
+++ b/docs/bounty-gap-audit.md
@@ -14,23 +14,32 @@ This audit is intentionally reviewer-facing: it separates what works now from wh
 ## Current State
 
 - The repository is public: `https://github.com/ChaiWithJai/annotated-canvas`.
-- Production is live through local Wrangler deployment:
+- Production is live through GitHub Actions deploy-from-main. Run `25212955639` completed successfully from head SHA `2963f02d37bff4d862e00027f7774688ff9f5e26`.
   - Web: `https://annotated-canvas.pages.dev`
   - API health: `https://annotated-canvas-api.jaybhagat841.workers.dev/api/health`
-- GitHub Actions verification is green after PR #31, but deploy-from-main is still gated off because Cloudflare GitHub secrets and `CLOUDFLARE_DEPLOY_ENABLED=true` are not installed.
+  - Approved public smoke annotation: `https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`
+- Issue #22 is closed. Cloudflare deployment plumbing is no longer a bounty blocker.
+- The deployed MVP has API-level smoke for health, feed, profile, permalink, source link, 60-second media metadata, and signed-out/auth-not-configured behavior.
 - The Chrome extension builds to `dist/extension`, loads unpacked locally, opens as an MV3 side panel, saves an API base URL, and has local current-tab publish evidence.
-- PR #31 fixed the inert sign-in UI and deployed the safer production state: Google/X buttons now surface `auth_not_configured` instead of doing nothing or minting fake production sessions.
-- Real OAuth provider exchange, production extension p95 smoke, durable recorded-audio storage, and owned-media 240p policy remain open.
+- Production extension p95 proof is still open: exact selected text, exact real media `currentTime`, browser no-network rejection for >90 seconds, and audio/microphone behavior are not yet recorded against production.
+- Real OAuth provider exchange, durable recorded-audio storage, and owned-media 240p policy remain open.
+
+## Evidence Split
+
+- **Working deployed MVP**: public Pages/Worker URLs, feed/profile/permalink routes, source-linked public annotation, comments/claim intake from earlier smoke, text commentary, and API-side 90-second validation.
+- **API-level smoke**: the approved smoke annotation `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` proves the production API can store and serve a source-linked 60-second annotation; it does not prove a real Chrome extension selected the quote or captured media time from a page.
+- **Extension p95 proof**: still required in #30/#23 before claiming the sidebar capture journey is bounty-complete.
+- **Human/platform blockers**: #24 needs real Google/X provider credentials and token exchange; #26 needs durable audio storage and a 240p/sub-480p owned-media decision.
 
 ## Bounty Requirement Matrix
 
 | Bounty requirement | Status bucket | Current evidence | Remaining gap | Delivery issue |
 | --- | --- | --- | --- | --- |
-| Sidebar Chrome extension | Working now | `dist/extension` loads unpacked; side panel opens; local publish proof in #30. | Production API-base publish and p95 capture evidence. | #30, #23 |
-| Highlight and clip media from any website | Deployed but limited | Current-tab URL/title, selected-text path, and media time-range controls exist. | Exact selected text and real media `currentTime` must be proven against production payloads. | #23, #30 |
-| Add commentary and annotations | Deployed but limited | Text commentary publishes; public annotation/comment/claim smoke exists. | Recorded audio commentary is not durably stored in production. | #26 |
-| Landing page linking back to original source | Working now | Public permalink exists and API returns canonical Pages `permalink_url`. | Continue to verify every created annotation carries `source_url`. | #21, #28 |
-| Public social feed | Working now | Public feed and profile routes return `200`; production annotation/comment smoke exists. | Final packet should use fresh proof immediately before external submission. | #28 |
+| Sidebar Chrome extension | Working now | `dist/extension` loads unpacked; side panel opens; local publish proof in #30. | Production API-base publish and p95 capture evidence from a real browser. | #30, #23 |
+| Highlight and clip media from any website | Deployed but limited | Current-tab URL/title, selected-text path, media time-range controls, and API-level production smoke exist. | Exact selected text and real media `currentTime` must be proven against production payloads. | #23, #30 |
+| Add commentary and annotations | Deployed but limited | Text commentary publishes; approved public annotation exists; earlier comment/claim smoke exists. | Recorded audio commentary is not durably stored in production. | #26 |
+| Landing page linking back to original source | Working now | Approved public permalink `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` returns the canonical Pages `permalink_url` and source link. | Continue to verify every created annotation carries `source_url`. | #21, #28 |
+| Public social feed | Working now | Public feed includes the approved smoke annotation; profile route returns `200`. | Final packet should use fresh proof immediately before external submission. | #28 |
 | Follow and engage with annotations | Working now | Comments and engagement paths are implemented; follow UI was wired to API before PR #31 merge. | Include follow/comment proof in final demo, not only local tests. | #23, closed #25 |
 | Account via X or Google | Blocked by human credentials/secrets | Production now fails closed with visible not-configured messages when provider secrets are absent. | Google/X apps, client secrets, token exchange, user/session creation, extension handoff. | #24 |
 | URL input or current page | Deployed but limited | Web URL composer and extension current-page capture exist. | Production extension publish and exact payload evidence still required. | #23, #30 |
@@ -41,7 +50,7 @@ This audit is intentionally reviewer-facing: it separates what works now from wh
 | Users can leave comments | Working now | Public smoke created `cmt_73c82db2-d4db-4661-b92e-84b12b4e74e7`. | Re-run before final submission if the seed data changes. | closed #25, #28 |
 | File a claim | Working now | Public smoke created `claim_36899790-f89f-4add-9744-046b5b46c3f3` and annotation remained public. | Final demo should explain claim is notice intake, not automatic takedown. | closed #27, #28 |
 | All content links to original source | Working now | Third-party clip contracts require `source_url`; permalink shows original source link. | Keep this invariant in extension p95 evidence. | #21, #23 |
-| Submit to annotated.lovable.app | Deployed but limited | Reviewer packet has live URLs, demo script, and honest blocker list. | Human decision to submit with disclosed gaps or wait for #22/#24/#26/#30. | #28 |
+| Submit to annotated.lovable.app | Deployed but limited | Reviewer packet has live URLs, demo script, approved smoke annotation, and honest blocker list. | Human decision to submit with disclosed gaps or wait for #23/#24/#26/#30. | #28 |
 
 ## Issue Acceptance Criteria
 
@@ -50,7 +59,7 @@ This audit is intentionally reviewer-facing: it separates what works now from wh
 - [ ] Gap audit and submission packet use the same status buckets.
 - [ ] Every open bounty gap links to a child issue or explicit product decision.
 - [ ] Final submission language distinguishes live MVP evidence from unfinished bounty-critical criteria.
-- [ ] Close only after #22/#23/#24/#26/#28/#30 are completed or deliberately disclosed by the submitter.
+- [ ] Close only after #23/#24/#26/#28/#30 are completed or deliberately disclosed by the submitter.
 
 Learning notes:
 
@@ -59,19 +68,19 @@ Learning notes:
 - **p50 test**: reviewer can load public web/API URLs and follow the demo script.
 - **p95 test**: every bounty-critical limitation is either closed with evidence or called out in the submission text.
 
-### #22 Cloudflare CLI Production Setup And Deployment
+### Closed #22 Cloudflare CLI Production Setup And Deployment
 
-- [ ] Production resources and smoke evidence remain documented.
-- [ ] GitHub `production` environment has `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`.
-- [ ] Repository variable `CLOUDFLARE_DEPLOY_ENABLED=true` is set only after secrets are ready.
-- [ ] GitHub Actions deploy-from-main runs instead of skipping and post-deploy smoke passes.
+- [x] Production resources and smoke evidence remain documented.
+- [x] GitHub `production` environment has `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`.
+- [x] Repository variable `CLOUDFLARE_DEPLOY_ENABLED=true` is set after secrets are ready.
+- [x] GitHub Actions deploy-from-main runs instead of skipping and post-deploy smoke passes.
 
 Learning notes:
 
-- **Developer/user must understand**: local Wrangler deployment proves the app can run; GitHub deploy-from-main proves repeatable release control.
-- **Pitfall**: enabling the deploy gate before production IDs/secrets are installed.
-- **p50 test**: `GET /api/health`, web root, feed, profile, permalink, comment, and claim work after local deploy.
-- **p95 test**: the same smoke passes from the commit deployed by GitHub Actions.
+- **Developer/user must understand**: local Wrangler deployment proved the app could run; GitHub deploy-from-main now proves repeatable release control.
+- **Pitfall**: a successful Worker deploy can still fail evidence collection if the CI parser expects the wrong log shape.
+- **p50 test**: `GET /api/health`, web root, feed, profile, permalink, comment, and claim work after deploy.
+- **p95 test**: run `25212955639` applied remote D1 migrations, deployed the Worker, built the web app against the deployed Worker URL, deployed Pages, and passed public smoke from the deployed commit.
 
 ### #23 Complete Extension And Web Capture Journey
 
@@ -150,7 +159,6 @@ Learning notes:
 
 ## Remaining Blockers
 
-- **#22**: GitHub deploy-from-main needs Cloudflare account ID/API token and the deploy gate enabled.
 - **#24**: Google/X OAuth needs provider apps, secrets, token exchange, user/session persistence, and extension handoff proof.
 - **#26**: R2 is not enabled, audio storage is fallback-only, and owned-media 240p policy is undecided.
 - **#30/#23**: production extension p95 smoke evidence is not yet recorded.

--- a/docs/bounty-gap-audit.md
+++ b/docs/bounty-gap-audit.md
@@ -22,6 +22,7 @@ This audit is intentionally reviewer-facing: it separates what works now from wh
 - The deployed MVP has API-level smoke for health, feed, profile, permalink, source link, 60-second media metadata, and signed-out/auth-not-configured behavior.
 - The Chrome extension builds to `dist/extension`, loads unpacked locally, opens as an MV3 side panel, saves an API base URL, and has local current-tab publish evidence.
 - Production extension p95 proof is still open: exact selected text, exact real media `currentTime`, browser no-network rejection for >90 seconds, and audio/microphone behavior are not yet recorded against production.
+- Reviewer onboarding still needs the #38 happy/sad path and Krug pass before filming the demo video.
 - Real OAuth provider exchange, durable recorded-audio storage, and owned-media 240p policy remain open.
 
 ## Evidence Split
@@ -29,6 +30,7 @@ This audit is intentionally reviewer-facing: it separates what works now from wh
 - **Working deployed MVP**: public Pages/Worker URLs, feed/profile/permalink routes, source-linked public annotation, comments/claim intake from earlier smoke, text commentary, and API-side 90-second validation.
 - **API-level smoke**: the approved smoke annotation `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` proves the production API can store and serve a source-linked 60-second annotation; it does not prove a real Chrome extension selected the quote or captured media time from a page.
 - **Extension p95 proof**: still required in #30/#23 before claiming the sidebar capture journey is bounty-complete.
+- **Reviewer journey proof**: #38 must turn marketing, signup, local extension install, extension capture, feed return, comments, and claim filing into one obvious happy/sad path before the demo video.
 - **Human/platform blockers**: #24 needs real Google/X provider credentials and token exchange; #26 needs durable audio storage and a 240p/sub-480p owned-media decision.
 
 ## Bounty Requirement Matrix
@@ -50,7 +52,7 @@ This audit is intentionally reviewer-facing: it separates what works now from wh
 | Users can leave comments | Working now | Public smoke created `cmt_73c82db2-d4db-4661-b92e-84b12b4e74e7`. | Re-run before final submission if the seed data changes. | closed #25, #28 |
 | File a claim | Working now | Public smoke created `claim_36899790-f89f-4add-9744-046b5b46c3f3` and annotation remained public. | Final demo should explain claim is notice intake, not automatic takedown. | closed #27, #28 |
 | All content links to original source | Working now | Third-party clip contracts require `source_url`; permalink shows original source link. | Keep this invariant in extension p95 evidence. | #21, #23 |
-| Submit to annotated.lovable.app | Deployed but limited | Reviewer packet has live URLs, demo script, approved smoke annotation, and honest blocker list. | Human decision to submit with disclosed gaps or wait for #23/#24/#26/#30. | #28 |
+| Submit to annotated.lovable.app | Deployed but limited | Reviewer packet has live URLs, demo script, approved smoke annotation, and honest blocker list. | Human decision to submit with disclosed gaps or wait for #23/#24/#26/#30/#38. | #28 |
 
 ## Issue Acceptance Criteria
 
@@ -59,7 +61,7 @@ This audit is intentionally reviewer-facing: it separates what works now from wh
 - [ ] Gap audit and submission packet use the same status buckets.
 - [ ] Every open bounty gap links to a child issue or explicit product decision.
 - [ ] Final submission language distinguishes live MVP evidence from unfinished bounty-critical criteria.
-- [ ] Close only after #23/#24/#26/#28/#30 are completed or deliberately disclosed by the submitter.
+- [ ] Close only after #23/#24/#26/#28/#30/#38 are completed or deliberately disclosed by the submitter.
 
 Learning notes:
 
@@ -157,9 +159,24 @@ Learning notes:
 - **p50 test**: side panel opens, saves API base, captures current tab, publishes one annotation.
 - **p95 test**: context menu selection, media current time, network suppression on invalid duration, and audio fallback are evidenced.
 
+### #38 Reviewer Journey Happy/Sad Paths And Krug Pass
+
+- [ ] Marketing, feed, signup, local extension install, capture, publish, feed return, comment, follow/engage, and claim steps are documented as one reviewer journey.
+- [ ] The web app exposes the local unpacked-extension path because Chrome Web Store distribution is not part of the MVP.
+- [ ] Auth, extension install, wrong API URL, no selection, over-90 media, audio/R2, and claim-submission recovery states have clear copy and test evidence.
+- [ ] The final demo script follows the same happy/sad paths without requiring improvisation.
+
+Learning notes:
+
+- **Developer/user must understand**: the reviewer journey is itself a product surface, not a documentation footnote.
+- **Pitfall**: a live route or working endpoint can still fail the bounty if the user cannot discover and complete the job.
+- **p50 test**: reviewer can discover, install/use, publish, and return to the feed using one script.
+- **p95 test**: auth blockers, unpacked-extension constraints, invalid ranges, audio limitations, and claim behavior are understandable at the point of action.
+
 ## Remaining Blockers
 
 - **#24**: Google/X OAuth needs provider apps, secrets, token exchange, user/session persistence, and extension handoff proof.
 - **#26**: R2 is not enabled, audio storage is fallback-only, and owned-media 240p policy is undecided.
 - **#30/#23**: production extension p95 smoke evidence is not yet recorded.
+- **#38**: reviewer journey happy/sad paths and Krug pass are not yet merged into the product/docs.
 - **#28**: external submission should wait for these gates or explicitly disclose them.

--- a/docs/submission-packet.md
+++ b/docs/submission-packet.md
@@ -13,6 +13,15 @@ Status buckets used below:
 - **Blocked by human credentials/secrets**: external account setup or secrets are required before final proof.
 - **Not yet implemented**: product/code/policy work remains.
 
+## Current Submission Status
+
+- **Working deployed MVP**: GitHub Actions deploy-from-main is proven by run `25212955639`; the public Pages and Worker URLs are live; the feed, profile, permalink, source-link, comment/claim intake, text commentary, and API-side 90-second validation have production evidence.
+- **Approved API-level smoke**: `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` is the current public smoke annotation. It proves the production API and web permalink can serve a source-linked 60-second annotation, not that a real Chrome extension captured selected text or media time from a page.
+- **Extension p95 still open**: #30/#23 still need browser evidence for production API-base persistence, exact selected text, exact real media `currentTime`, >90-second no-network rejection, and audio/microphone behavior.
+- **Auth blocker**: #24 still needs real Google/X apps, secrets, token exchange, user/session creation, and extension handoff. Production correctly fails closed with `auth_not_configured` today.
+- **Audio/240p blocker**: #26 still needs durable recorded-audio storage plus an explicit owned-media 240p/sub-480p policy. Third-party media remains source-linked by reference.
+- **Final submission requirement**: the human submitter must either wait for #23/#24/#26/#30 or copy the known-limitations language below into the external `annotated.lovable.app` submission.
+
 ## Submission Links
 
 Fill these in immediately before posting to `https://annotated.lovable.app`.
@@ -22,7 +31,7 @@ Fill these in immediately before posting to `https://annotated.lovable.app`.
 | Public web URL | `https://annotated-canvas.pages.dev` |
 | Public API health URL | `https://annotated-canvas-api.jaybhagat841.workers.dev/api/health` |
 | Public feed URL | `https://annotated-canvas.pages.dev/` |
-| Public annotation permalink | `https://annotated-canvas.pages.dev/a/ann_74ce284f-0516-41d1-a8f0-fdb0d3b824b0` |
+| Public annotation permalink | `https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` |
 | Public profile URL | `https://annotated-canvas.pages.dev/u/mira` |
 | Source repository | `https://github.com/ChaiWithJai/annotated-canvas` |
 | Local web URL | `http://127.0.0.1:5173` |
@@ -34,7 +43,7 @@ Public demo routes:
 
 - Feed: `https://annotated-canvas.pages.dev/`
 - Profile: `https://annotated-canvas.pages.dev/u/mira`
-- Annotation permalink: `https://annotated-canvas.pages.dev/a/ann_74ce284f-0516-41d1-a8f0-fdb0d3b824b0`
+- Annotation permalink: `https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`
 - Removed annotation state: `https://annotated-canvas.pages.dev/a/removed`
 
 Local demo routes:
@@ -87,15 +96,15 @@ Expected service name: `annotated-canvas-api`.
 
 Target length: 8-10 minutes.
 
-1. Open the public web URL or local feed at `http://127.0.0.1:5173/`.
+1. Open the public web URL at `https://annotated-canvas.pages.dev/`.
 2. Show the public feed, source-domain labels, engagement counts, and `File a claim` button.
-3. Open `http://127.0.0.1:5173/u/mira` and show the creator profile and annotation list.
-4. Open `http://127.0.0.1:5173/a/ann_video_minimalism` and show the permalink, original source link, commentary, and clip metadata.
-5. Show local demo auth start URLs for Google and X:
+3. Open `https://annotated-canvas.pages.dev/u/mira` and show the creator profile and annotation list.
+4. Open `https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` and show the permalink, original source link, commentary, and 60-second clip metadata.
+5. Show production auth failing closed until provider secrets exist:
 
    ```bash
-   curl "http://localhost:8787/api/auth/google/start?return_to=http://127.0.0.1:5173/"
-   curl "http://localhost:8787/api/auth/x/start?return_to=http://127.0.0.1:5173/"
+   curl "https://annotated-canvas-api.jaybhagat841.workers.dev/api/auth/google/start?return_to=https://annotated-canvas.pages.dev/"
+   curl "https://annotated-canvas-api.jaybhagat841.workers.dev/api/auth/x/start?return_to=https://annotated-canvas.pages.dev/"
    ```
 
 6. Load the unpacked Chrome extension from `dist/extension`.
@@ -162,10 +171,10 @@ curl -X POST http://localhost:8787/api/claims \
 
 | Bounty item | Reviewer evidence | Current status |
 | --- | --- | --- |
-| Sidebar Chrome extension | MV3 side panel loaded from `dist/extension`; side panel opens on source pages. | **Working now** locally; production p50/p95 proof remains #30/#23. |
-| Highlight and clip text/audio/video from any website | Current-tab context, selected text, and media time-range UI/API payloads. | **Deployed but limited**; exact selected-text and real media-time proof remain #23/#30. |
+| Sidebar Chrome extension | MV3 side panel loaded from `dist/extension`; side panel opens on source pages. | **Working now** locally; production p50/p95 browser proof remains #30/#23. |
+| Highlight and clip text/audio/video from any website | Current-tab context, selected text, media time-range UI/API payloads, and approved production API-level smoke. | **Deployed but limited**; exact selected-text and real media-time browser proof remain #23/#30. |
 | Add commentary and annotations | Text commentary publish path and API contract. | **Deployed but limited**; recorded audio is fallback-only until #26. |
-| Landing page links back to original source | Annotation permalink includes source metadata and original source link. | **Working now** with public permalink smoke. |
+| Landing page links back to original source | Approved annotation permalink includes source metadata and original source link. | **Working now** with public permalink smoke `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`. |
 | Public social feed | Feed route and API feed path. | **Working now** with public Worker and Pages smoke. |
 | Users can follow and engage | Feed/profile engagement, follow route, comments, and counts. | **Working now**; include fresh follow/comment proof in final demo. |
 | Account via X or Google | Sign-in buttons call the API and production fails closed when secrets are absent. | **Blocked by human credentials/secrets**; real provider exchange remains #24. |
@@ -177,16 +186,16 @@ curl -X POST http://localhost:8787/api/claims \
 | Users can leave comments | Comment resources and claim/feed docs reflect local completion. | **Working now**; public smoke created `cmt_73c82db2-d4db-4661-b92e-84b12b4e74e7`. |
 | File a claim button | Claim button/modal and `POST /api/claims` notice intake. | **Working now**; public smoke created `claim_36899790-f89f-4add-9744-046b5b46c3f3` and annotation remained public. |
 | All content links to original source | `source_url` required for third-party clips. | **Working now** for third-party contracts/API. |
-| Submit to annotated.lovable.app | Packet, URLs, demo script, and checklist. | **Deployed but limited**; external submission needs final disclosure or completion of open gates. |
+| Submit to annotated.lovable.app | Packet, URLs, demo script, approved smoke annotation, and checklist. | **Deployed but limited**; external submission needs final disclosure or completion of open gates. |
 
 ## Open-Issue Acceptance Notes
 
-These notes are the reviewer handoff for the seven open tickets. The longer form lives in `docs/bounty-gap-audit.md`.
+These notes are the reviewer handoff for the six open tickets plus the closed Cloudflare dependency. The longer form lives in `docs/bounty-gap-audit.md`.
 
 | Issue | Close only when | Learning note | p50 evidence | p95 evidence |
 | --- | --- | --- | --- | --- |
 | #21 Bounty readiness | The status buckets are current and every gap is closed or explicitly disclosed. | A live MVP is not a complete bounty claim. | Public URLs and demo script work. | No bounty-critical limitation is hidden. |
-| #22 Cloudflare deployment | GitHub Actions deploy-from-main runs and public smoke passes from that commit. | Local Wrangler proves capability; CI deploy proves repeatability. | Local-deployed web/API smoke works. | GitHub-deployed smoke works after secrets are installed. |
+| Closed #22 Cloudflare deployment | Closed after GitHub Actions deploy-from-main and public smoke passed from run `25212955639`. | Local Wrangler proved capability; CI deploy now proves repeatability. | Public web/API smoke works. | GitHub-deployed smoke passed from head SHA `2963f02d37bff4d862e00027f7774688ff9f5e26`. |
 | #23 Capture journey | Web URL/current-page, selected text, and media time payloads reconcile with stored annotations. | Functional fields are not proof unless payloads match user intent. | One normal annotation publishes. | Exact quote/timecode/source integrity are proven. |
 | #24 OAuth | Google/X provider exchange, sessions, and extension handoff work with real credentials. | Honest not-configured failure is safer than fake account creation. | Signed-out and provider-start behavior is visible. | Invalid/replayed state, logout, and anonymous extension-token rejection are tested. |
 | #26 Audio/240p | Recorded audio persists and owned-media 240p/sub-480p policy is implemented or explicitly excluded. | Third-party references and owned media processing are different rights surfaces. | Text commentary and audio intent behavior are clear. | Stored audio, upload validation, and owned-video rendition policy are enforceable. |
@@ -198,7 +207,6 @@ These notes are the reviewer handoff for the seven open tickets. The longer form
 Open issue snapshot for `ChaiWithJai/annotated-canvas`:
 
 - #21 `Epic: Bounty gap audit and submission readiness`
-- #22 `Epic: Cloudflare CLI production setup and deployment`
 - #23 `Epic: Complete extension and web capture journey`
 - #24 `Epic: Real X/Google auth and extension handoff`
 - #26 `Epic: Audio commentary and 240p media policy`
@@ -207,6 +215,7 @@ Open issue snapshot for `ChaiWithJai/annotated-canvas`:
 
 Recently completed issue evidence relevant to the packet:
 
+- #22 `Epic: Cloudflare CLI production setup and deployment`
 - #25 `Epic: Public feed, comments, follows, and engagement parity`
 - #27 `Task: Harden claim filing into a reviewable notice workflow`
 
@@ -229,17 +238,20 @@ Production extension p50/p95 proof still to record:
 
 Production smoke evidence recorded on May 1, 2026:
 
-- `GET https://annotated-canvas-api.jaybhagat841.workers.dev/api/health` returned `200`.
-- `GET https://annotated-canvas.pages.dev/`, `/u/mira`, `/a/removed`, and `/a/ann_74ce284f-0516-41d1-a8f0-fdb0d3b824b0` returned `200`.
-- `POST /api/annotations` created `ann_74ce284f-0516-41d1-a8f0-fdb0d3b824b0`.
-- `GET /api/annotations/ann_74ce284f-0516-41d1-a8f0-fdb0d3b824b0` returns canonical `permalink_url: https://annotated-canvas.pages.dev/a/ann_74ce284f-0516-41d1-a8f0-fdb0d3b824b0`.
-- `POST /api/annotations/ann_74ce284f-0516-41d1-a8f0-fdb0d3b824b0/comments` created `cmt_73c82db2-d4db-4661-b92e-84b12b4e74e7`.
-- `POST /api/claims` created `claim_36899790-f89f-4add-9744-046b5b46c3f3`, and `GET /api/annotations/ann_74ce284f-0516-41d1-a8f0-fdb0d3b824b0` still returned `200`.
-- `POST /api/uploads/audio-commentary` returned `status: intent-created`, confirming the R2-disabled fallback path.
+- GitHub Actions run `25212955639` completed successfully from `main` at `2963f02d37bff4d862e00027f7774688ff9f5e26`.
+- The run passed typecheck, unit/integration tests, Worker runtime tests, build, Cloudflare production preflight, remote D1 migrations, Worker deploy, production web build, and Pages deploy.
+- `GET https://annotated-canvas-api.jaybhagat841.workers.dev/api/health` returned `200` with `ok: true`, `service: annotated-canvas-api`, and `mode: production`.
+- `GET https://annotated-canvas.pages.dev/`, `/home`, `/u/mira`, and `/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` returned `200`.
+- `GET /api/annotations/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` returns canonical `permalink_url: https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`.
+- `GET /api/feed` includes `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`.
+- `GET /api/me` from the Pages origin returned `401 authentication_required`, which is the expected signed-out state.
+- Google and X auth start endpoints returned `503 auth_not_configured`, listing the missing provider client IDs/secrets.
+- Earlier production API smoke created comment `cmt_73c82db2-d4db-4661-b92e-84b12b4e74e7`, claim notice `claim_36899790-f89f-4add-9744-046b5b46c3f3`, and `POST /api/uploads/audio-commentary` returned `status: intent-created`.
+- Important boundary: this is API-level production smoke. It does not replace #30 browser p95 proof for exact selected text, real media current time, or no-network rejection from the unpacked extension.
 
 ## Known Blockers Before External Submission
 
-- Public deployment is live. #22 remains open for GitHub CI/CD secret wiring and final deploy-from-main proof.
+- Public deployment is live and #22 is closed. Do not list Cloudflare deploy-from-main as a remaining blocker.
 - Real Google/X OAuth needs provider client IDs/secrets, callback configuration, token exchange, and production-safe sessions. Tracked by #24.
 - Extension and web capture need final proof that user-entered text/time selections bind exactly to the publish payload. Tracked by #23.
 - Selected-text context menu, real media current-time capture, over-90-second browser validation, and audio commentary remain p95 extension proof gaps. Tracked by #30 and #26.
@@ -249,13 +261,12 @@ Production smoke evidence recorded on May 1, 2026:
 
 Submission language to use if posting before all blockers close:
 
-> Annotated Canvas is live as a source-linked MVP with public feed, permalinks, comments, claim filing, text commentary, and local unpacked Chrome side-panel proof. The remaining disclosed gaps are real Google/X OAuth credentials and token exchange, production extension p95 proof for exact selected text/media timing, durable recorded-audio storage, owned-media 240p processing policy, and GitHub Actions deploy-from-main wiring.
+> Annotated Canvas is live as a source-linked MVP with GitHub-deployed public Pages/Worker URLs, public feed, permalinks, comments, claim filing, text commentary, API-level 90-second validation, and local unpacked Chrome side-panel proof. The current approved public smoke annotation is `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`. The remaining disclosed gaps are real Google/X OAuth credentials and token exchange, production Chrome extension p95 proof for exact selected text/media timing and >90-second no-network rejection, durable recorded-audio storage, and owned-media 240p processing policy.
 
 Dependency gate map: `output/reports/gas-town/dependency-gate-map.md`.
 
 External inputs required before this packet can claim full bounty coverage:
 
-- Cloudflare account ID and scoped API token approved for GitHub `production` secrets, plus approval to set `CLOUDFLARE_DEPLOY_ENABLED=true` and prove deploy-from-main.
 - Google OAuth app credentials for `https://annotated-canvas-api.jaybhagat841.workers.dev/api/auth/google/callback`.
 - X OAuth app credentials for `https://annotated-canvas-api.jaybhagat841.workers.dev/api/auth/x/callback`.
 - R2 enablement for bucket `annotated-canvas-media`, or an approved alternate storage path for recorded audio commentary.
@@ -265,7 +276,9 @@ External inputs required before this packet can claim full bounty coverage:
 
 - [x] Public web URL is live and replaces the placeholder above.
 - [x] Public API health URL returns OK and replaces the placeholder above.
+- [x] GitHub Actions deploy-from-main is proven by run `25212955639`.
 - [x] Public feed, profile, permalink, removed state, and claim flow are smoke-tested.
+- [x] Approved public smoke annotation is current: `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`.
 - [x] Chrome extension builds with `npm run build:extension`.
 - [x] Unpacked extension loads from `dist/extension` and side panel opens in Chrome.
 - [ ] Extension Settings saves the production Worker URL and publishes through that API base without source edits.

--- a/docs/submission-packet.md
+++ b/docs/submission-packet.md
@@ -20,7 +20,8 @@ Status buckets used below:
 - **Extension p95 still open**: #30/#23 still need browser evidence for production API-base persistence, exact selected text, exact real media `currentTime`, >90-second no-network rejection, and audio/microphone behavior.
 - **Auth blocker**: #24 still needs real Google/X apps, secrets, token exchange, user/session creation, and extension handoff. Production correctly fails closed with `auth_not_configured` today.
 - **Audio/240p blocker**: #26 still needs durable recorded-audio storage plus an explicit owned-media 240p/sub-480p policy. Third-party media remains source-linked by reference.
-- **Final submission requirement**: the human submitter must either wait for #23/#24/#26/#30 or copy the known-limitations language below into the external `annotated.lovable.app` submission.
+- **Reviewer journey blocker**: #38 must make the marketing/feed/signup/local-extension/capture/return loop dead simple before filming the demo video.
+- **Final submission requirement**: the human submitter must either wait for #23/#24/#26/#30/#38 or copy the known-limitations language below into the external `annotated.lovable.app` submission.
 
 ## Submission Links
 
@@ -190,7 +191,7 @@ curl -X POST http://localhost:8787/api/claims \
 
 ## Open-Issue Acceptance Notes
 
-These notes are the reviewer handoff for the six open tickets plus the closed Cloudflare dependency. The longer form lives in `docs/bounty-gap-audit.md`.
+These notes are the reviewer handoff for the seven open tickets plus the closed Cloudflare dependency. The longer form lives in `docs/bounty-gap-audit.md`.
 
 | Issue | Close only when | Learning note | p50 evidence | p95 evidence |
 | --- | --- | --- | --- | --- |
@@ -201,6 +202,7 @@ These notes are the reviewer handoff for the six open tickets plus the closed Cl
 | #26 Audio/240p | Recorded audio persists and owned-media 240p/sub-480p policy is implemented or explicitly excluded. | Third-party references and owned media processing are different rights surfaces. | Text commentary and audio intent behavior are clear. | Stored audio, upload validation, and owned-video rendition policy are enforceable. |
 | #28 Submission package | The external post uses current URLs, smoke IDs, and known limitations. | The packet is a reviewer script plus truth-in-advertising checklist. | Reviewer can run the demo without reading code. | Reviewer can reproduce highest-risk claims from linked evidence. |
 | #30 Extension smoke | Production extension p50 and p95 browser evidence is recorded. | MV3 side-panel proof must happen in Chrome, not only in unit tests. | Side panel saves API base and publishes one annotation. | Selected text, media current time, over-90 no-network rejection, and audio fallback are evidenced. |
+| #38 Reviewer journey | The happy/sad path and Krug pass are merged before filming. | Reviewer onboarding is a product surface, not a doc appendix. | Reviewer can discover, install/use, publish, and return to the feed from one script. | Auth, extension install, invalid range, audio/R2, and claim recovery states are understandable at the point of action. |
 
 ## Current Open GitHub Issues
 
@@ -212,6 +214,7 @@ Open issue snapshot for `ChaiWithJai/annotated-canvas`:
 - #26 `Epic: Audio commentary and 240p media policy`
 - #28 `Task: Prepare final bounty submission package`
 - #30 `Task: Local Chrome extension install and bounty smoke verification`
+- #38 `P0: Codify reviewer journey happy/sad paths and Krug pass before demo video`
 
 Recently completed issue evidence relevant to the packet:
 
@@ -258,10 +261,11 @@ Production smoke evidence recorded on May 1, 2026:
 - Audio commentary recording/finalize and 240p owned-media policy remain unresolved. Tracked by #26.
 - R2 is not enabled in the Cloudflare account yet. Production omits the R2 binding, so audio upload storage remains blocked by #26.
 - Chrome Web Store distribution is not part of the local MVP; reviewers load `dist/extension` unpacked.
+- Reviewer journey happy/sad paths and the Krug pass must land before filming the demo video. Tracked by #38.
 
 Submission language to use if posting before all blockers close:
 
-> Annotated Canvas is live as a source-linked MVP with GitHub-deployed public Pages/Worker URLs, public feed, permalinks, comments, claim filing, text commentary, API-level 90-second validation, and local unpacked Chrome side-panel proof. The current approved public smoke annotation is `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`. The remaining disclosed gaps are real Google/X OAuth credentials and token exchange, production Chrome extension p95 proof for exact selected text/media timing and >90-second no-network rejection, durable recorded-audio storage, and owned-media 240p processing policy.
+> Annotated Canvas is live as a source-linked MVP with GitHub-deployed public Pages/Worker URLs, public feed, permalinks, comments, claim filing, text commentary, API-level 90-second validation, and local unpacked Chrome side-panel proof. The current approved public smoke annotation is `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`. The remaining disclosed gaps are real Google/X OAuth credentials and token exchange, production Chrome extension p95 proof for exact selected text/media timing and >90-second no-network rejection, durable recorded-audio storage, owned-media 240p processing policy, and the final reviewer journey/Krug pass before demo filming.
 
 Dependency gate map: `output/reports/gas-town/dependency-gate-map.md`.
 
@@ -293,5 +297,6 @@ External inputs required before this packet can claim full bounty coverage:
 - [x] `File a claim` records a notice and does not automatically remove content.
 - [ ] Audio commentary limitation is documented with microphone/upload evidence and the production R2 `intent-created` fallback.
 - [ ] Demo Google and X auth behavior is documented, or production OAuth is fully configured.
+- [ ] Reviewer journey happy/sad paths and Krug pass from #38 are merged before filming.
 - [ ] Known limitations are copied into the bounty submission without hiding bounty-critical gaps.
 - [ ] Submission is posted to `https://annotated.lovable.app`.


### PR DESCRIPTION
## What changed

- Reconciles `docs/bounty-gap-audit.md` and `docs/submission-packet.md` after #22 closed with GitHub-driven Cloudflare deploy success.
- Replaces the stale public smoke annotation with approved annotation `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`.
- Adds README submission status with live URLs, closed #22 deploy evidence, and remaining bounty blockers.

## Readiness stance

This keeps the packet honest: the deployed MVP is working and API-smoked, but final bounty completion still depends on #23/#30 extension p95 proof, #24 real Google/X OAuth, #26 durable audio/240p policy, and #28 human submission approval.

## Verification

- `gh run view 25212955639 --repo ChaiWithJai/annotated-canvas --json status,conclusion,headSha,displayTitle,event,createdAt,updatedAt,url,workflowName,jobs`
- `curl -fsS https://annotated-canvas-api.jaybhagat841.workers.dev/api/health`
- `curl -fsS -o /dev/null -w '%{http_code} %{url_effective}\n' https://annotated-canvas.pages.dev/`
- `curl -fsS -o /dev/null -w '%{http_code} %{url_effective}\n' https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`
- `curl -fsS https://annotated-canvas-api.jaybhagat841.workers.dev/api/annotations/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`
- `curl -fsS 'https://annotated-canvas-api.jaybhagat841.workers.dev/api/feed'`
- `git diff --check`
