### PR TITLE
[codex] expose extension publish smoke evidence

### DIFF
--- a/apps/extension/src/sidepanel/SidePanel.tsx
+++ b/apps/extension/src/sidepanel/SidePanel.tsx
@@ -1,6 +1,19 @@
 import { SourceRefSchema, toSourceDomain } from "@annotated/contracts";
 import { Button, SourcePill } from "@annotated/ui";
-import { Clock, FileText, Layers, Mic, RotateCcw, Save, Scissors, Send, Settings, Square, UserCircle } from "lucide-react";
+import {
+  Clock,
+  ExternalLink,
+  FileText,
+  Layers,
+  Mic,
+  RotateCcw,
+  Save,
+  Scissors,
+  Send,
+  Settings,
+  Square,
+  UserCircle
+} from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   DEFAULT_API_BASE,
@@ -13,6 +26,7 @@ import {
   saveApiBase,
   saveCaptureDraft,
   type CaptureDraft,
+  type PublishAnnotationResult,
   type PageCaptureContext
 } from "./api";
 
@@ -42,6 +56,9 @@ export function SidePanel() {
   const [settingsStatus, setSettingsStatus] = useState<string | null>(null);
   const [savedDraft, setSavedDraft] = useState<CaptureDraft | null>(null);
   const [draftStatus, setDraftStatus] = useState<string | null>(null);
+  const [publishedAnnotation, setPublishedAnnotation] = useState<PublishAnnotationResult["annotation"] | null>(
+    null
+  );
   const recorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<BlobPart[]>([]);
 
@@ -132,25 +149,33 @@ export function SidePanel() {
   async function publish() {
     setStatus("publishing");
     setError(null);
+    setPublishedAnnotation(null);
     try {
       const startSeconds = parseTimeInput(startTime);
       const endSeconds = parseTimeInput(endTime);
+      if (captureKind === "video" && endSeconds <= startSeconds) {
+        throw new Error("invalid_range");
+      }
       if (captureKind === "video" && endSeconds - startSeconds > 90) {
         throw new Error("range_too_long");
       }
-      await publishAnnotation({
+      const result = await publishAnnotation({
         context: pageContext ?? {},
         commentary,
         captureKind,
         range: { start_seconds: startSeconds, end_seconds: endSeconds },
         audioBlob: commentaryMode === "audio" ? audioBlob : null
       });
+      setPublishedAnnotation(result.annotation);
       setStatus("published");
+      setMode("annotations");
     } catch (caught) {
       setStatus("idle");
       setError(
         caught instanceof Error && caught.message === "range_too_long"
           ? "Clip length must be 90 seconds or less."
+          : caught instanceof Error && caught.message === "invalid_range"
+            ? "End time must be after start time."
           : "Could not publish. Confirm the API URL in Settings."
       );
     }
@@ -332,8 +357,32 @@ export function SidePanel() {
           )}
         </section>
       ) : (
-        <section className="empty-pane">
-          <p>Published items appear in the API feed after publish.</p>
+        <section className="published-pane">
+          {publishedAnnotation ? (
+            <article className="published-card">
+              <div>
+                <strong>Last publish</strong>
+                <span>{publishedAnnotation.id}</span>
+              </div>
+              <dl>
+                <div>
+                  <dt>Permalink</dt>
+                  <dd>
+                    <a href={publishedAnnotation.permalink_url} target="_blank" rel="noreferrer">
+                      <ExternalLink size={14} aria-hidden="true" />
+                      Open permalink
+                    </a>
+                  </dd>
+                </div>
+                <div>
+                  <dt>Source</dt>
+                  <dd>{publishedAnnotation.clip.source?.source_url ?? "Uploaded source"}</dd>
+                </div>
+              </dl>
+            </article>
+          ) : (
+            <p>Published items appear in the API feed after publish.</p>
+          )}
         </section>
       )}
 

--- a/apps/extension/src/sidepanel/api.test.ts
+++ b/apps/extension/src/sidepanel/api.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { fixtures, type AnnotationResource } from "@annotated/contracts";
 import {
   PRODUCTION_API_BASE,
   publishAnnotation,
@@ -8,6 +9,18 @@ import {
   saveApiBase,
   saveCaptureDraft
 } from "./api";
+
+function annotationResponse(id: string): Response {
+  const annotation: AnnotationResource = {
+    ...fixtures.annotations[0],
+    id,
+    permalink_url: `https://annotated.example/a/${id}`
+  };
+  return new Response(JSON.stringify({ annotation }), {
+    status: 201,
+    headers: { "Content-Type": "application/json" }
+  });
+}
 
 function stubChromeStorage(initialValues: Record<string, unknown> = {}) {
   const storage = new Map<string, unknown>(Object.entries(initialValues));
@@ -34,12 +47,7 @@ describe("extension publish API", () => {
   });
 
   it("publishes the exact p50 time range entered in the side panel", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ annotation: { id: "ann_test" } }), {
-        status: 201,
-        headers: { "Content-Type": "application/json" }
-      })
-    );
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(annotationResponse("ann_test"));
 
     await publishAnnotation({
       context: {
@@ -64,6 +72,31 @@ describe("extension publish API", () => {
     });
   });
 
+  it("returns the published annotation id and permalink for browser smoke evidence", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(annotationResponse("ann_smoke"));
+
+    await expect(
+      publishAnnotation({
+        context: {
+          source_url: "https://example.com/video",
+          title: "Example video",
+          media: { current_time: 12, kind: "video" }
+        },
+        commentary: "Expose the publish result for smoke proof.",
+        captureKind: "video",
+        range: {
+          start_seconds: 12,
+          end_seconds: 70
+        }
+      })
+    ).resolves.toMatchObject({
+      annotation: {
+        id: "ann_smoke",
+        permalink_url: "https://annotated.example/a/ann_smoke"
+      }
+    });
+  });
+
   it("rejects p95 time ranges above the 90 second bounty cap before fetch", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch");
 
@@ -81,6 +114,27 @@ describe("extension publish API", () => {
         }
       })
     ).rejects.toThrow();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects reversed p95 media ranges before fetch instead of mutating the entered end time", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    await expect(
+      publishAnnotation({
+        context: {
+          source_url: "https://example.com/video",
+          title: "Example video"
+        },
+        commentary: "This should not publish.",
+        captureKind: "video",
+        range: {
+          start_seconds: 70,
+          end_seconds: 12
+        }
+      })
+    ).rejects.toThrow("invalid_range");
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -109,12 +163,7 @@ describe("extension publish API", () => {
   });
 
   it("publishes exact p95 selected text from the context-menu capture path", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ annotation: { id: "ann_text" } }), {
-        status: 201,
-        headers: { "Content-Type": "application/json" }
-      })
-    );
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(annotationResponse("ann_text"));
 
     await publishAnnotation({
       context: {
@@ -149,12 +198,7 @@ describe("extension publish API", () => {
           headers: { "Content-Type": "application/json" }
         })
       )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ annotation: { id: "ann_audio" } }), {
-          status: 201,
-          headers: { "Content-Type": "application/json" }
-        })
-      );
+      .mockResolvedValueOnce(annotationResponse("ann_audio"));
 
     await publishAnnotation({
       context: {
@@ -182,12 +226,7 @@ describe("extension publish API", () => {
 
   it("uses the stored API base so review builds can target production without source edits", async () => {
     stubChromeStorage();
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ annotation: { id: "ann_test" } }), {
-        status: 201,
-        headers: { "Content-Type": "application/json" }
-      })
-    );
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(annotationResponse("ann_test"));
 
     await saveApiBase(`${PRODUCTION_API_BASE}/`);
     expect(await readApiBase()).toBe(PRODUCTION_API_BASE);

--- a/apps/extension/src/sidepanel/api.ts
+++ b/apps/extension/src/sidepanel/api.ts
@@ -1,4 +1,10 @@
-import { AnnotationCreateSchema, SourceRefSchema, toSourceDomain } from "@annotated/contracts";
+import {
+  AnnotationCreateSchema,
+  AnnotationResourceSchema,
+  SourceRefSchema,
+  toSourceDomain,
+  type AnnotationResource
+} from "@annotated/contracts";
 
 export const DEFAULT_API_BASE = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8787";
 export const PRODUCTION_API_BASE = "https://annotated-canvas-api.jaybhagat841.workers.dev";
@@ -39,8 +45,17 @@ export interface CaptureDraft {
   saved_at: string;
 }
 
+export interface PublishAnnotationResult {
+  annotation: AnnotationResource;
+}
+
 function normalizeApiBase(value: string): string {
   return value.trim().replace(/\/+$/, "");
+}
+
+function floorNonNegative(value: number | undefined, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.floor(value));
 }
 
 export async function readApiBase(): Promise<string> {
@@ -124,7 +139,7 @@ async function uploadAudioCommentary(audioBlob: Blob): Promise<string> {
   return payload.upload.asset_id ?? payload.upload.id;
 }
 
-export async function publishAnnotation(options: PublishOptions) {
+export async function publishAnnotation(options: PublishOptions): Promise<PublishAnnotationResult> {
   const { context, commentary, captureKind, range, audioBlob } = options;
   const apiBase = await readApiBase();
   const sourceUrl = context.source_url ?? "https://www.youtube.com/watch?v=annotated-demo&t=263s";
@@ -133,10 +148,13 @@ export async function publishAnnotation(options: PublishOptions) {
     source_domain: toSourceDomain(sourceUrl),
     title: context.title || "Untitled source"
   });
-  const currentTime = Math.max(0, Math.floor(context.media?.current_time ?? 263));
-  const startSeconds = Math.max(0, Math.floor(range?.start_seconds ?? currentTime));
-  const endSeconds = Math.max(startSeconds + 1, Math.floor(range?.end_seconds ?? currentTime + 47));
+  const currentTime = floorNonNegative(context.media?.current_time, 263);
+  const startSeconds = floorNonNegative(range?.start_seconds, currentTime);
+  const endSeconds = floorNonNegative(range?.end_seconds, currentTime + 47);
   const durationSeconds = endSeconds - startSeconds;
+  if (captureKind === "video" && durationSeconds <= 0) {
+    throw new Error("invalid_range");
+  }
   if (captureKind === "video" && durationSeconds > 90) {
     throw new Error("range_too_long");
   }
@@ -186,5 +204,8 @@ export async function publishAnnotation(options: PublishOptions) {
     body: JSON.stringify(payload)
   });
   if (!response.ok) throw new Error("publish failed");
-  return response.json();
+  const responsePayload = (await response.json()) as { annotation?: unknown };
+  return {
+    annotation: AnnotationResourceSchema.parse(responsePayload.annotation)
+  };
 }

--- a/apps/extension/src/sidepanel/api.ts
+++ b/apps/extension/src/sidepanel/api.ts
@@ -54,7 +54,7 @@ function normalizeApiBase(value: string): string {
 }
 
 function floorNonNegative(value: number | undefined, fallback: number): number {
-  if (!Number.isFinite(value)) return fallback;
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
   return Math.max(0, Math.floor(value));
 }
 

--- a/apps/extension/src/sidepanel/sidepanel.css
+++ b/apps/extension/src/sidepanel/sidepanel.css
@@ -208,9 +208,70 @@ body {
   font-size: 12px;
 }
 
-.empty-pane {
+.empty-pane,
+.published-pane {
   padding: 28px 20px;
   color: var(--ac-muted);
+}
+
+.published-card {
+  border: 1px solid var(--ac-border);
+  border-radius: var(--ac-radius);
+  padding: 14px;
+  display: grid;
+  gap: 14px;
+  color: var(--ac-muted);
+}
+
+.published-card > div {
+  display: grid;
+  gap: 4px;
+}
+
+.published-card strong {
+  color: var(--ac-text);
+  font-size: 14px;
+}
+
+.published-card span,
+.published-card dt,
+.published-card dd,
+.published-card p {
+  margin: 0;
+  font-size: 12px;
+}
+
+.published-card span {
+  font-family: var(--ac-mono);
+  overflow-wrap: anywhere;
+}
+
+.published-card dl {
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.published-card dl div {
+  display: grid;
+  gap: 4px;
+}
+
+.published-card dt {
+  color: var(--ac-text);
+  font-weight: 700;
+}
+
+.published-card dd {
+  overflow-wrap: anywhere;
+}
+
+.published-card a {
+  color: var(--ac-primary);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  text-decoration: none;
 }
 
 .draft-pane {

--- a/docs/chrome-extension-local-smoke.md
+++ b/docs/chrome-extension-local-smoke.md
@@ -94,6 +94,7 @@ Expected response shape:
 - [x] Settings tab saves the API URL in `chrome.storage.local`.
 - [x] Settings tab includes local and production API-base presets.
 - [x] Capture tab can save and restore the latest local draft from Chrome extension storage.
+- [x] Published tab shows the last production/local annotation id and permalink returned by `POST /api/annotations`.
 - [ ] Settings tab saves `https://annotated-canvas-api.jaybhagat841.workers.dev`, survives side-panel close/reopen, and publishes to the production Worker without source edits.
 - [ ] On a text page, select text, right-click, choose `Annotate selected text`, and confirm the side panel displays the selected text path.
 - [x] On a normal page, confirm the side panel reads the active tab URL/title through the content-script/tab fallback path.
@@ -101,7 +102,24 @@ Expected response shape:
 - [x] Enter a range of 90 seconds or less, add commentary, publish, and confirm the local API returns success.
 - [x] Verify the created annotation appears in the API feed or web client.
 - [ ] Enter a range over 90 seconds and confirm publish is blocked with `Clip length must be 90 seconds or less.` before the network publish.
+- [ ] Enter an end time at or before the start time and confirm publish is blocked with `End time must be after start time.` before the network publish.
 - [ ] Record a voice note, handle the microphone prompt, and publish it if the local API upload path is available; otherwise record the exact blocker.
+
+## Worker B Audit, May 1 2026
+
+Current implementation status against `bounty.txt`:
+
+| Requirement | Current extension status |
+| --- | --- |
+| Sidebar Chrome extension | Implemented as MV3 side panel with `chrome.sidePanel` and loadable `dist/extension`. Needs refreshed production browser screenshot/recording. |
+| Current page URL | Implemented through content-script `ANNOTATED_READ_CONTEXT` with a tab URL/title fallback. Local Chrome proof exists; production URL publish still needs evidence. |
+| Selected text | Implemented through context menu `Annotate selected text`, one-shot `pendingCapture`, and `clip.text.quote` trimming. Needs browser proof that the exact selected quote is preserved in production payload and stored annotation. |
+| Audio/video time range | Implemented through top-level `video, audio` current-time capture and side-panel Start/End fields. Needs browser proof on real media that seeded seconds match `POST /api/annotations`. |
+| Commentary | Implemented for text commentary and recorded audio commentary upload-before-publish. Audio storage remains limited by the current production upload fallback until #26 enables durable R2 storage. |
+| Publish to production API | Implemented through persisted Settings API base and Production preset. Needs side-panel production proof using `https://annotated-canvas-api.jaybhagat841.workers.dev`. |
+| Permalink/feed proof | API returns the annotation resource with `id` and `permalink_url`; the side panel now surfaces the last publish id/permalink in the Published tab for smoke evidence. |
+| Stale state handling | Pending selected-text captures are cleared after one read, local drafts are explicit, and failed publishes clear any previous publish result before retry. |
+| 90-second cap | Implemented in side panel and publish helper before audio upload or annotation fetch. Reversed/zero-length media ranges are now rejected before fetch instead of being silently adjusted. |
 
 ## Automated Extension Coverage
 
@@ -117,7 +135,9 @@ Covered cases:
 - p50 media publish preserves the exact entered start/end/duration.
 - p95 media ranges over 90 seconds throw `range_too_long` before annotation fetch.
 - p95 audio commentary with a range over 90 seconds throws before upload or annotation fetch.
+- Reversed media ranges throw `invalid_range` before annotation fetch.
 - p95 selected-text publish trims and preserves the exact quote in `clip.text.quote` and uses `client_context.capture_method: "selection"`.
+- Publish responses are parsed into a full annotation resource so the side panel can show the returned id and permalink.
 - Production API-base persistence normalizes `https://annotated-canvas-api.jaybhagat841.workers.dev/` to `https://annotated-canvas-api.jaybhagat841.workers.dev`.
 - Pending selected-text capture clears after one read.
 - Local capture drafts persist with trimmed commentary.
@@ -171,6 +191,8 @@ API base saved:
 5. Fetch the returned annotation or `GET https://annotated-canvas-api.jaybhagat841.workers.dev/api/feed` and confirm the new id appears.
 
 Evidence to retain: side-panel source screenshot, Network `POST /api/annotations` request to the production Worker, request JSON with `client_context.surface: "extension"`, response annotation id, feed/permalink/API proof for that id, and the exact commentary string used for correlation.
+
+After publish, open the side panel Published tab and record the returned annotation id/permalink displayed there before switching tabs or retrying a publish.
 
 Template:
 
@@ -351,3 +373,39 @@ Capture these in `docs/issue-learning-loop.md` or the issue thread after browser
 - Over-90-second client-side validation still needs browser proof, even though unit coverage exercises the publish path.
 - Audio commentary needs microphone permission and upload proof; production currently returns the R2-disabled `intent-created` fallback until #26 enables durable storage.
 - Production API URL switching needs browser proof against `https://annotated-canvas-api.jaybhagat841.workers.dev`.
+
+## Worker B Issue Comment Draft
+
+Use this for #23 and #30 after this branch lands or as a coordination update:
+
+```md
+Worker B extension smoke audit update, May 1 2026:
+
+Code/doc changes are scoped to `apps/extension/**` and `docs/chrome-extension-local-smoke.md`.
+
+What changed:
+- The extension publish helper now parses the production `POST /api/annotations` response into a full annotation resource.
+- The side panel Published tab now shows the last returned annotation id and permalink, so p50/p95 smoke evidence can record the production id without digging through DevTools.
+- Media publishes now reject zero-length or reversed ranges before upload/fetch with `End time must be after start time.` instead of silently changing the entered end time.
+- The smoke doc now maps the current extension state against `bounty.txt` and calls out remaining browser proof.
+
+Verified:
+- `npx vitest run apps/extension/src/sidepanel/api.test.ts --environment node --no-file-parallelism --maxWorkers=1 --pool=forks --isolate=false --reporter=verbose` -> 10 extension tests passed.
+- `npm run build:extension` -> rebuilt `dist/extension`.
+- `npm run typecheck` -> passed.
+- `curl -i https://annotated-canvas-api.jaybhagat841.workers.dev/api/health` -> `200`, `mode: "production"`.
+- `curl -i https://annotated-canvas.pages.dev/` -> `200`.
+
+Not completed in this pass:
+- I did not load/reload the unpacked extension in desktop Chrome because installing/loading a browser extension is a user-confirmed action.
+- I did not create a new public production annotation because that posts public test content and should be confirmed at action time.
+- `npm test` still hung in the combined Vitest node startup path before spawning workers; the focused extension suite passed.
+
+Close gate still needs browser evidence:
+- Save `https://annotated-canvas-api.jaybhagat841.workers.dev` in side-panel Settings and confirm it persists after reopen.
+- Publish one production p50 annotation and record the side-panel Published id/permalink plus API/feed proof.
+- Use `Annotate selected text` on a normal page and prove the exact quote is preserved in payload and stored annotation.
+- Use a real `<video>` or `<audio>` page and prove current time -> Start/End -> production media seconds.
+- Enter a >90s range and prove the side-panel error appears with no production `POST /api/annotations`.
+- Record microphone/audio upload behavior and the current #26 durable-storage limitation.
+```


### PR DESCRIPTION
## What changed

- Parses the production `POST /api/annotations` response as an annotation resource so the extension can show a concrete id and permalink after publish.
- Adds a Published tab state with last annotation id, source, and permalink for smoke evidence.
- Blocks reversed/zero-length media ranges before upload/fetch, matching the existing >90 second client-side guard.
- Expands the Chrome extension smoke checklist with the bounty audit, p50/p95 evidence still needed, and issue-comment handoff notes.

## Verification reported by the worker

- `npx vitest run apps/extension/src/sidepanel/api.test.ts --environment node --no-file-parallelism --maxWorkers=1 --pool=forks --isolate=false --reporter=verbose` -> 10 passed
- `npm run build:extension` -> passed
- `npm run typecheck` -> passed
- `curl -i https://annotated-canvas-api.jaybhagat841.workers.dev/api/health` -> `200`, `mode: "production"`
- `curl -i https://annotated-canvas.pages.dev/` -> `200`

`npm test` and full `npm run build` hung locally, so GitHub CI is authoritative.

## Remaining #23/#30 work

This PR improves the evidence path but does not replace the required real-browser production proof: load/reload `dist/extension`, save the production Worker API base, publish from a real tab, prove selected text and media time payloads, and capture the over-90 no-network rejection.
