### PR TITLE
[codex] harden OAuth and extension handoff

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -214,14 +214,15 @@ describe("API router regression coverage", () => {
     expect((await body(token)).token_type).toBe("Bearer");
   });
 
-  it("fails closed for oauth start when credentials or session KV are missing", async () => {
+  it("fails closed for oauth start when credentials, D1, or session KV are missing", async () => {
     const missingSecret = await handleRequest(
       request("/api/auth/google/start?return_to=/"),
       {
         ...env,
         AUTH_MODE: "oauth",
         GOOGLE_CLIENT_ID: "google-client",
-        SESSION_KV: createSessionKv()
+        SESSION_KV: createSessionKv(),
+        DB: createAuthDb()
       },
       { repository, jobs }
     );
@@ -232,13 +233,32 @@ describe("API router regression coverage", () => {
     expect(missingSecretPayload.error.details.missing).toContain("GOOGLE_CLIENT_SECRET");
     expect(missingSecretPayload.authorization_url).toBeUndefined();
 
+    const missingDb = await handleRequest(
+      request("/api/auth/google/start?return_to=/"),
+      {
+        ...env,
+        AUTH_MODE: "oauth",
+        GOOGLE_CLIENT_ID: "google-client",
+        GOOGLE_CLIENT_SECRET: "google-secret",
+        SESSION_KV: createSessionKv()
+      },
+      { repository, jobs }
+    );
+    const missingDbPayload = await body(missingDb);
+
+    expect(missingDb.status).toBe(503);
+    expect(missingDbPayload.error.code).toBe("auth_not_configured");
+    expect(missingDbPayload.error.details.missing).toContain("DB");
+    expect(missingDbPayload.authorization_url).toBeUndefined();
+
     const missingKv = await handleRequest(
       request("/api/auth/x/start?return_to=/"),
       {
         ...env,
         AUTH_MODE: "oauth",
         X_CLIENT_ID: "x-client",
-        X_CLIENT_SECRET: "x-secret"
+        X_CLIENT_SECRET: "x-secret",
+        DB: createAuthDb()
       },
       { repository, jobs }
     );
@@ -248,6 +268,19 @@ describe("API router regression coverage", () => {
     expect(missingKvPayload.error.code).toBe("auth_not_configured");
     expect(missingKvPayload.error.details.missing).toContain("SESSION_KV");
     expect(missingKvPayload.authorization_url).toBeUndefined();
+  });
+
+  it("rejects unsupported auth providers before start or callback handling", async () => {
+    const start = await handleRequest(request("/api/auth/mastodon/start?return_to=/"), env, { repository, jobs });
+    const callback = await handleRequest(request("/api/auth/mastodon/callback?state=state_1&code=demo"), env, {
+      repository,
+      jobs
+    });
+
+    expect(start.status).toBe(400);
+    expect((await body(start)).error.code).toBe("unsupported_auth_provider");
+    expect(callback.status).toBe(400);
+    expect((await body(callback)).error.code).toBe("unsupported_auth_provider");
   });
 
   it("validates state, exchanges provider code, persists local user and session, and rejects replay", async () => {
@@ -340,6 +373,76 @@ describe("API router regression coverage", () => {
     );
     expect(replayedCallback.status).toBe(400);
     expect((await body(replayedCallback)).error.code).toBe("invalid_oauth_state");
+  });
+
+  it("serves p50 X oauth callback and ties extension handoff to the web session", async () => {
+    const sessionKv = createSessionKv();
+    const db = createAuthDb();
+    const oauth = createOAuthClient({
+      provider: "x",
+      provider_account_id: "x-user-456",
+      handle: "annotator_x",
+      display_name: "Annotator X",
+      avatar_url: "https://profiles.example/x.png"
+    });
+    const oauthEnv: Env = {
+      ...env,
+      AUTH_MODE: "oauth",
+      X_CLIENT_ID: "x-client",
+      X_CLIENT_SECRET: "x-secret",
+      SESSION_KV: sessionKv,
+      DB: db
+    };
+
+    const start = await body(
+      await handleRequest(request("/api/auth/x/start?return_to=/extension"), oauthEnv, { repository, jobs })
+    );
+    expect(start.authorization_url).toContain("twitter.com");
+
+    const callback = await handleRequest(request(`/api/auth/x/callback?state=${start.state}&code=x-code`), oauthEnv, {
+      repository,
+      jobs,
+      oauth
+    });
+    expect(callback.status).toBe(302);
+    expect(callback.headers.get("Location")).toBe("http://localhost:5173/extension");
+    expect(db.users.size).toBe(1);
+    expect(db.oauthAccounts.size).toBe(1);
+    expect(db.sessions.size).toBe(1);
+
+    const sessionId = callback.headers.get("Set-Cookie")?.match(/annotated_session=([^;]+)/)?.[1];
+    expect(sessionId).toBeTruthy();
+    const token = await handleRequest(
+      request("/api/auth/extension-token", {
+        method: "POST",
+        headers: {
+          Cookie: `annotated_session=${sessionId}`
+        }
+      }),
+      oauthEnv,
+      { repository, jobs }
+    );
+    expect(token.status).toBe(200);
+    const tokenPayload = await body(token);
+    const storedToken = JSON.parse(sessionKv.store.get(`extension_token:${tokenPayload.token}`) ?? "{}");
+    expect(storedToken).toMatchObject({
+      session_id: sessionId,
+      provider: "x",
+      handle: "annotator_x",
+      display_name: "Annotator X"
+    });
+
+    const exchangeCall = oauth.calls.find(
+      (call): call is { type: "exchange"; input: any } => call.type === "exchange"
+    );
+    expect(exchangeCall?.input).toMatchObject({
+      provider: "x",
+      code: "x-code",
+      client_id: "x-client",
+      client_secret: "x-secret"
+    });
+    expect(exchangeCall?.input.redirect_uri).toBe("https://api.annotated.test/api/auth/x/callback");
+    expect(exchangeCall?.input.code_verifier).toEqual(expect.any(String));
   });
 
   it("fails oauth callback closed for missing config without consuming state", async () => {
@@ -459,6 +562,11 @@ describe("API router regression coverage", () => {
     const tokenPayload = await body(token);
     expect(tokenPayload.token_type).toBe("Bearer");
     expect(sessionKv.store.has(`extension_token:${tokenPayload.token}`)).toBe(true);
+    expect(JSON.parse(sessionKv.store.get(`extension_token:${tokenPayload.token}`) ?? "{}")).toMatchObject({
+      user_id: "usr_oauth",
+      provider: "google",
+      session_id: "ses_valid"
+    });
   });
 
   it("deletes the session on logout when session KV is available", async () => {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -35,6 +35,7 @@ interface OAuthState {
 }
 
 interface AuthSession {
+  session_id?: string;
   user_id: string;
   provider?: AuthProvider;
   handle?: string;
@@ -177,6 +178,7 @@ function missingOAuthConfig(env: Env, provider: AuthProvider): string[] {
   return [
     !credentials.clientId ? credentials.clientIdName : null,
     !credentials.clientSecret ? credentials.clientSecretName : null,
+    !env.DB ? "DB" : null,
     !env.SESSION_KV ? "SESSION_KV" : null
   ].filter((item): item is string => Boolean(item));
 }
@@ -266,7 +268,7 @@ async function requireOAuthSession(request: Request, env: Env): Promise<AuthSess
     return error(env, 401, "authentication_required", "A valid session is required.", {}, request);
   }
 
-  return session;
+  return { ...session, session_id: sessionId };
 }
 
 function resolveReturnTo(env: Env, rawReturnTo: string | null): string {
@@ -360,12 +362,7 @@ async function findUniqueHandle(db: D1Database, desiredHandle: string, userId?: 
 async function upsertOAuthUser(env: Env, profile: OAuthProviderProfile): Promise<PersistedOAuthUser> {
   const fallbackHandle = `${profile.provider}_${profile.provider_account_id}`;
   if (!env.DB) {
-    return {
-      id: `usr_${profile.provider}_${profile.provider_account_id}`,
-      handle: normalizeHandle(profile.handle, fallbackHandle),
-      display_name: profile.display_name,
-      avatar_url: profile.avatar_url
-    };
+    throw new Error("db_required");
   }
 
   const existing = await env.DB
@@ -442,6 +439,7 @@ async function storeExtensionToken(env: Env, session: AuthSession): Promise<{ to
       `extension_token:${token}`,
       JSON.stringify({
         user_id: session.user_id,
+        session_id: session.session_id,
         provider: session.provider,
         handle: session.handle,
         display_name: session.display_name

--- a/docs/cloudflare-cli.md
+++ b/docs/cloudflare-cli.md
@@ -136,6 +136,7 @@ Auth and media gates are separate:
 
 - Google callback URL: `https://annotated-canvas-api.jaybhagat841.workers.dev/api/auth/google/callback`.
 - X callback URL: `https://annotated-canvas-api.jaybhagat841.workers.dev/api/auth/x/callback`.
+- OAuth Worker bindings: `DB` and `SESSION_KV`; `AUTH_MODE=oauth` returns `503 auth_not_configured` when either binding is missing.
 - R2 bucket name, if enabled: `annotated-canvas-media`.
 - Worker binding to restore after storage exists: `MEDIA_BUCKET`.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -245,7 +245,9 @@ curl "http://localhost:8787/api/auth/x/start?return_to=http://127.0.0.1:5173/"
 
 In demo mode, the API returns an authorization URL that points directly to the local callback instead of redirecting to a real provider.
 
-The extension currently shows a signed-out limitation message because real extension OAuth handoff is not complete. Publishing still works against the API using the server-side demo author until the auth branch lands real provider credentials and token handoff.
+Real OAuth requires `AUTH_MODE=oauth`, the `DB` and `SESSION_KV` bindings, and provider secrets for the selected provider. When those are present, callbacks exchange the provider code, link or create the local user, write the browser session, and allow `POST /api/auth/extension-token` to mint a one-hour extension handoff token for that web session.
+
+Production remains intentionally fail-closed until the Google and X OAuth apps are created and `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `X_CLIENT_ID`, and `X_CLIENT_SECRET` are installed as Worker secrets.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What changed

- OAuth mode now fails closed if D1 `DB` is missing, instead of allowing synthetic OAuth users.
- OAuth user creation now requires D1, while demo auth remains separate.
- Extension-token handoff payload records the originating `session_id` for tighter session traceability.
- Adds tests for X OAuth callback + extension handoff, unsupported providers, missing DB config, and stronger extension-token session assertions.
- Updates Cloudflare/user docs with real OAuth requirements and remaining provider-secret setup.

## Verification reported by the worker

- `npm exec -- vitest run apps/api/src/app.test.ts --environment node --no-file-parallelism --maxWorkers=1 --pool=forks --isolate=false` -> 22 tests passed on the worker branch.
- `npm run typecheck` -> passed.
- `git diff --check` -> passed.

I merged the auth test changes onto current main after PR #39 so the audio/media tests are preserved. Local Vitest in the parent shell hung before reporter output, so GitHub CI is authoritative for this PR.

## Remaining #24 blockers

Repo-side auth is closer, but external completion still needs HITL/provider setup and production smoke:

- Google OAuth app callback: `https://annotated-canvas-api.jaybhagat841.workers.dev/api/auth/google/callback` with scopes `openid email profile`, secrets `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`.
- X OAuth app callback: `https://annotated-canvas-api.jaybhagat841.workers.dev/api/auth/x/callback` with scopes `users.read tweet.read`, secrets `X_CLIENT_ID` / `X_CLIENT_SECRET`.
- Production proof after secrets: provider start redirects to provider, callback sets `annotated_session`, `/api/me` works with cookie, anonymous extension-token is 401, authenticated extension-token returns Bearer token, logout invalidates session.
