### PR TITLE
[codex] codify reviewer journey and Krug pass

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -99,6 +99,8 @@ describe("Annotated web shell", () => {
     expect(screen.getByRole("heading", { name: /save the exact moment/i })).toBeInTheDocument();
     expect(screen.getByText("Sign in with Google")).toBeInTheDocument();
     expect(screen.getByText("View public feed")).toBeInTheDocument();
+    expect(screen.getByText("Extension install guide")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /see the feed, load the extension/i })).toBeInTheDocument();
   });
 
   it("checks signed-out session state with credentials on load", async () => {
@@ -150,6 +152,8 @@ describe("Annotated web shell", () => {
       });
     });
     expect(screen.getByRole("alert")).toHaveTextContent(/google sign-in is not configured/i);
+    expect(screen.getByRole("alert")).toHaveTextContent(/load the unpacked extension/i);
+    expect(screen.getByText("Install extension")).toBeInTheDocument();
   });
 
   it("starts X auth through fetch and follows the returned authorization URL", async () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,6 +22,8 @@ import {
 
 type View = "home" | "feed" | "profile" | "annotation" | "empty" | "removed" | "signup";
 type ViewerState = "loading" | "signed-in" | "signed-out";
+const REVIEWER_GUIDE_URL =
+  "https://github.com/ChaiWithJai/annotated-canvas/blob/main/docs/reviewer-journey.md";
 
 function clipSource(clip: AnnotationResource["clip"]) {
   return "source" in clip ? clip.source : undefined;
@@ -350,12 +352,44 @@ export function App() {
               <button type="button" onClick={() => navigate("feed")}>
                 View public feed
               </button>
+              <a href={REVIEWER_GUIDE_URL} target="_blank" rel="noreferrer">
+                Extension install guide
+              </a>
             </div>
             {authError ? (
-              <p className="auth-error" role="alert">
-                {authError}
-              </p>
+              <div className="auth-recovery" role="alert">
+                <strong>{authError}</strong>
+                <p>For review, load the unpacked extension and use the production API in Settings.</p>
+                <div className="auth-recovery__actions">
+                  <button type="button" onClick={() => navigate("feed")}>
+                    View feed
+                  </button>
+                  <a href={REVIEWER_GUIDE_URL} target="_blank" rel="noreferrer">
+                    Install extension
+                  </a>
+                </div>
+              </div>
             ) : null}
+            <section className="review-path" aria-label="Reviewer path">
+              <div>
+                <p className="eyebrow">Review path</p>
+                <h3>See the feed, load the extension, publish, return.</h3>
+              </div>
+              <ol className="review-path__steps">
+                <li>
+                  <span>1</span>
+                  <p>Open the public feed and an annotation permalink.</p>
+                </li>
+                <li>
+                  <span>2</span>
+                  <p>Build `dist/extension`, load it unpacked, and save the production API URL.</p>
+                </li>
+                <li>
+                  <span>3</span>
+                  <p>Publish from a source tab, then verify the permalink, comment, and claim paths.</p>
+                </li>
+              </ol>
+            </section>
             <div className="feed-list marketing-preview">
               {feedItems.slice(0, 2).map((annotation) => (
                 <AnnotationCard
@@ -566,7 +600,7 @@ export function App() {
           {[
             "Original source is always linked",
             "Clips stop at 90 seconds",
-            "Sign in with X or Google",
+            "Unpacked extension supported for review",
             "Claims ask for human review",
             "Retries do not duplicate posts"
           ].map((item) => (
@@ -577,7 +611,7 @@ export function App() {
           ))}
           <div className="notify">
             <Bell size={18} aria-hidden="true" />
-            <p>Open the source from any card before you quote, comment, or file a claim.</p>
+            <p>Google/X sign-in needs provider credentials; review can continue with the feed and unpacked extension.</p>
           </div>
         </aside>
       </main>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -247,6 +247,95 @@
   font-size: 13px;
 }
 
+.auth-recovery {
+  border: 1px solid color-mix(in srgb, var(--ac-danger) 38%, var(--ac-border));
+  border-radius: var(--ac-radius);
+  background: color-mix(in srgb, var(--ac-danger) 7%, var(--ac-surface));
+  padding: 14px;
+}
+
+.auth-recovery strong {
+  display: block;
+  color: var(--ac-danger);
+  font-size: 14px;
+}
+
+.auth-recovery p {
+  margin: 6px 0 0;
+  color: var(--ac-muted);
+  font-size: 13px;
+}
+
+.auth-recovery__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.auth-recovery__actions a,
+.auth-recovery__actions button {
+  min-height: 34px;
+  border: 1px solid var(--ac-border);
+  border-radius: var(--ac-radius);
+  background: var(--ac-surface);
+  color: var(--ac-text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.review-path {
+  border: 1px solid var(--ac-border);
+  border-radius: var(--ac-radius);
+  background: var(--ac-surface);
+  padding: 16px;
+  display: grid;
+  gap: 14px;
+}
+
+.review-path h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.review-path__steps {
+  display: grid;
+  gap: 10px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.review-path__steps li {
+  display: grid;
+  grid-template-columns: 26px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+}
+
+.review-path__steps span {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--ac-primary);
+  color: #fff;
+  display: inline-grid;
+  place-items: center;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.review-path__steps p {
+  margin: 1px 0 0;
+  color: var(--ac-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
 .marketing-preview {
   margin-top: 8px;
 }

--- a/docs/reviewer-journey.md
+++ b/docs/reviewer-journey.md
@@ -1,0 +1,51 @@
+# Reviewer Journey And Krug Pass
+
+Use this as the script before recording the demo video. It reconciles `bounty.txt`, the public app, and the local unpacked Chrome extension path.
+
+## p50 Happy Path
+
+1. Open `https://annotated-canvas.pages.dev/home`.
+2. Confirm the first screen says what the app does, links to the public feed, and exposes `Extension install guide`.
+3. Open `https://annotated-canvas.pages.dev/` and scan source domains, engagement, and `File a claim`.
+4. Open `https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`.
+5. Confirm the permalink has commentary, media timing, author, original source link, comments, and claim action.
+6. Build and load the extension locally:
+
+   ```bash
+   npm run build:extension
+   ```
+
+   Then open `chrome://extensions`, enable Developer Mode, click `Load unpacked`, and select `dist/extension`.
+
+7. Open a source page, open the extension side panel, choose `Settings`, select `Production`, and save.
+8. Capture selected text or a media time range of 90 seconds or less, add commentary, and publish.
+9. Copy the returned annotation id/permalink from the `Published` tab.
+10. Return to the web feed/permalink and verify the source link, comment path, and claim path.
+
+## p95 Sad Paths
+
+| Path | Expected behavior | Evidence |
+| --- | --- | --- |
+| Google/X not configured | Signup shows the provider blocker and points to feed plus unpacked extension review path. | Web screenshot and `/api/auth/*/start` response. |
+| Extension not installed | Web onboarding links to the install guide; docs say `dist/extension`, not source folders. | Home screenshot and install proof. |
+| Wrong API URL | Side panel Settings lets reviewer switch Local/Production without source edits. | Settings screenshot after reopen. |
+| No selected text | Selected-text proof must show exact browser selection, preview, payload, and stored quote. | Screenshot plus request/response. |
+| Reversed or over-90 range | Side panel blocks publish before network; API/contracts reject direct invalid payload. | Error screenshot and no `POST /api/annotations`. |
+| Audio storage unavailable | UI/docs disclose R2 `intent-created`; do not claim durable audio playback. | Upload response and #26 link. |
+| Claim submitted | Claim is recorded as review intake and does not automatically remove the annotation. | Claim id/status and permalink still visible. |
+
+## Krug Guardrails
+
+- The page name and next action must be visible without reading docs.
+- Buttons must name the action: `View public feed`, `Extension install guide`, `Publish annotation`, `File a claim`.
+- Do not claim Google/X auth is complete until provider secrets and production smoke pass.
+- Do not hide the Chrome Web Store gap; local unpacked install is part of the review path.
+- Keep source links and claim actions visible on every annotation surface.
+- Keep recovery copy near the failed action.
+
+## Testing Trophy
+
+- **Static/contract**: source URL required, media duration <= 90 seconds, audio asset id required, idempotency required.
+- **Integration**: feed, permalink, comments, claims, auth failure, extension-token handoff.
+- **Browser smoke**: home/feed/permalink screenshots, extension Settings persistence, p50 publish, selected-text proof, media-time proof, over-90 no-network proof.
+- **Manual proof**: Chrome unpacked extension installation and microphone prompt behavior.


### PR DESCRIPTION
## What changed

- Adds a first-screen reviewer path to the web client: view feed, load the unpacked extension, publish, return.
- Exposes `Extension install guide` from home/signup because the MVP is not in the Chrome Web Store.
- Replaces the ambiguous auth error paragraph with a recovery state that points reviewers to the feed and unpacked extension path when Google/X provider setup is missing.
- Updates trust-rail copy so it does not claim Google/X auth is complete before provider secrets and smoke are done.
- Adds `docs/reviewer-journey.md` with p50 happy path, p95 sad paths, Krug guardrails, and testing-trophy evidence.
- Updates web tests for the reviewer path and auth recovery copy.

## Verification

- `git diff --check -- apps/web/src/App.tsx apps/web/src/styles.css apps/web/src/App.test.tsx docs/reviewer-journey.md` passed locally.
- Local targeted web Vitest hung before reporter output in this desktop shell, so GitHub CI is authoritative.

## Issue

Closes the implementation checklist for #38 if CI passes and the deployed screenshots are refreshed after merge.
