### PR TITLE
docs: reconcile submission packet after p95 smoke

### DIFF
--- a/docs/bounty-gap-audit.md
+++ b/docs/bounty-gap-audit.md
@@ -14,45 +14,44 @@ This audit is intentionally reviewer-facing: it separates what works now from wh
 ## Current State
 
 - The repository is public: `https://github.com/ChaiWithJai/annotated-canvas`.
-- Production is live through GitHub Actions deploy-from-main. Run `25212955639` completed successfully from head SHA `2963f02d37bff4d862e00027f7774688ff9f5e26`.
+- Production is live through GitHub Actions deploy-from-main. Run `25216210247` completed successfully from head SHA `afa7e3dda7645c875785546f904798e449339ec2`.
   - Web: `https://annotated-canvas.pages.dev`
   - API health: `https://annotated-canvas-api.jaybhagat841.workers.dev/api/health`
   - Approved public smoke annotation: `https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`
 - Issue #22 is closed. Cloudflare deployment plumbing is no longer a bounty blocker.
-- The deployed MVP has API-level smoke for health, feed, profile, permalink, source link, 60-second media metadata, and signed-out/auth-not-configured behavior.
-- The Chrome extension builds to `dist/extension`, loads unpacked locally, opens as an MV3 side panel, saves an API base URL, and has local current-tab publish evidence.
-- Production extension p95 proof is still open: exact selected text, exact real media `currentTime`, browser no-network rejection for >90 seconds, and audio/microphone behavior are not yet recorded against production.
-- Reviewer onboarding still needs the #38 happy/sad path and Krug pass before filming the demo video.
+- The deployed MVP has smoke for health, feed, profile, permalink, source link, 60-second media metadata, comments/claim intake, and signed-out/auth-not-configured behavior.
+- The Chrome extension builds to `dist/extension`, loads unpacked locally, opens as an MV3 side panel, saves an API base URL, and has merged production p95 evidence from #43.
+- Issues #23, #30, and #38 are closed. Current-tab capture, exact selected text, exact media seconds, >90-second no-network rejection, and reviewer journey/Krug evidence are no longer bounty blockers.
 - Real OAuth provider exchange, durable recorded-audio storage, and owned-media 240p policy remain open.
 
 ## Evidence Split
 
-- **Working deployed MVP**: public Pages/Worker URLs, feed/profile/permalink routes, source-linked public annotation, comments/claim intake from earlier smoke, text commentary, and API-side 90-second validation.
-- **API-level smoke**: the approved smoke annotation `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` proves the production API can store and serve a source-linked 60-second annotation; it does not prove a real Chrome extension selected the quote or captured media time from a page.
-- **Extension p95 proof**: still required in #30/#23 before claiming the sidebar capture journey is bounty-complete.
-- **Reviewer journey proof**: #38 must turn marketing, signup, local extension install, extension capture, feed return, comments, and claim filing into one obvious happy/sad path before the demo video.
+- **Working deployed MVP**: public Pages/Worker URLs, feed/profile/permalink routes, source-linked public annotation, comments/claim intake from earlier smoke, text commentary, web URL composer, extension p95 capture proof, and API/extension-side 90-second validation.
+- **API-level smoke**: the approved smoke annotation `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` proves the production API can store and serve a source-linked 60-second annotation.
+- **Extension p95 proof**: PR #43 records selected-text, media-time, current-tab publish, over-90 no-network rejection, stored API reads, public permalinks, and audio upload fallback.
+- **Reviewer journey proof**: #38 records the marketing/feed/signup/local-extension/capture/return loop plus Krug guardrails before demo filming.
 - **Human/platform blockers**: #24 needs real Google/X provider credentials and token exchange; #26 needs durable audio storage and a 240p/sub-480p owned-media decision.
 
 ## Bounty Requirement Matrix
 
 | Bounty requirement | Status bucket | Current evidence | Remaining gap | Delivery issue |
 | --- | --- | --- | --- | --- |
-| Sidebar Chrome extension | Working now | `dist/extension` loads unpacked; side panel opens; local publish proof in #30. | Production API-base publish and p95 capture evidence from a real browser. | #30, #23 |
-| Highlight and clip media from any website | Deployed but limited | Current-tab URL/title, selected-text path, media time-range controls, and API-level production smoke exist. | Exact selected text and real media `currentTime` must be proven against production payloads. | #23, #30 |
+| Sidebar Chrome extension | Working now | `dist/extension` loads unpacked; side panel opens; production p95 evidence from PR #43 proves API-base persistence, current-tab publish, selected text, media time, and over-90 no-network rejection. | Chrome Web Store distribution remains out of scope for MVP; reviewers load unpacked. | closed #30, closed #23 |
+| Highlight and clip media from any website | Working now for text/video references | Current-tab URL/title, selected-text path, media time-range controls, API-level smoke, and extension p95 selected-text/media-time proof exist. | Durable recorded audio and owned-video processing remain separate media work. | closed #23, closed #30, #26 |
 | Add commentary and annotations | Deployed but limited | Text commentary publishes; approved public annotation exists; earlier comment/claim smoke exists. | Recorded audio commentary is not durably stored in production. | #26 |
 | Landing page linking back to original source | Working now | Approved public permalink `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` returns the canonical Pages `permalink_url` and source link. | Continue to verify every created annotation carries `source_url`. | #21, #28 |
 | Public social feed | Working now | Public feed includes the approved smoke annotation; profile route returns `200`. | Final packet should use fresh proof immediately before external submission. | #28 |
-| Follow and engage with annotations | Working now | Comments and engagement paths are implemented; follow UI was wired to API before PR #31 merge. | Include follow/comment proof in final demo, not only local tests. | #23, closed #25 |
+| Follow and engage with annotations | Working now | Comments and engagement paths are implemented; follow UI was wired to API before PR #31 merge. | Include follow/comment proof in final demo, not only local tests. | #28, closed #25 |
 | Account via X or Google | Blocked by human credentials/secrets | Production now fails closed with visible not-configured messages when provider secrets are absent. | Google/X apps, client secrets, token exchange, user/session creation, extension handoff. | #24 |
-| URL input or current page | Deployed but limited | Web URL composer and extension current-page capture exist. | Production extension publish and exact payload evidence still required. | #23, #30 |
-| Prompt for start/end or text section | Deployed but limited | UI/API support text quote and media start/end; API rejects invalid duration. | Browser proof must show user-entered values are the values sent and stored. | #23, #30 |
-| Max clip size 90 seconds | Working now | Contract/API tests reject media over 90 seconds; browser plan records client-side proof requirement. | p95 proof that extension blocks before production network request. | #30 |
+| URL input or current page | Working now | Web URL composer is tested; extension current-page capture has production p95 proof. | Final demo should show both paths clearly. | #28, closed #23, closed #30 |
+| Prompt for start/end or text section | Working now | UI/API support text quote and media start/end; extension p95 proves selected quote and exact media seconds. | Final demo should reuse the p95 evidence links. | #28, closed #23, closed #30 |
+| Max clip size 90 seconds | Working now | Contract/API tests reject media over 90 seconds; extension p95 shows no production `POST /api/annotations` for a 91-second range. | None for MVP. | closed #30 |
 | Downgrade clip to 240p / below 480p | Not yet implemented | Current MVP keeps third-party media source-linked by reference and now rejects upload/storage fields on third-party media contracts. | Human product/legal decision and owned-upload processing rule are required. | #26 |
 | Text or recorded audio commentary | Deployed but limited | Text works; audio upload endpoint returns an intent when R2 is unavailable; API rejects audio commentary with no `audio_asset_id`. | R2 or alternate storage, upload size/type rejection, finalize semantics, permalink playback/loading proof. | #26 |
 | Users can leave comments | Working now | Public smoke created `cmt_73c82db2-d4db-4661-b92e-84b12b4e74e7`. | Re-run before final submission if the seed data changes. | closed #25, #28 |
 | File a claim | Working now | Public smoke created `claim_36899790-f89f-4add-9744-046b5b46c3f3` and annotation remained public. | Final demo should explain claim is notice intake, not automatic takedown. | closed #27, #28 |
-| All content links to original source | Working now | Third-party clip contracts require `source_url`; permalink shows original source link. | Keep this invariant in extension p95 evidence. | #21, #23 |
-| Submit to annotated.lovable.app | Deployed but limited | Reviewer packet has live URLs, demo script, approved smoke annotation, and honest blocker list. | Human decision to submit with disclosed gaps or wait for #23/#24/#26/#30/#38. | #28 |
+| All content links to original source | Working now | Third-party clip contracts require `source_url`; permalink shows original source link; extension p95 stores original source metadata. | Keep this invariant in final demo. | #21, #28 |
+| Submit to annotated.lovable.app | Deployed but limited | Reviewer packet has live URLs, demo script, approved smoke annotation, p95 extension evidence, and honest blocker list. | Human decision to submit with #24/#26 disclosed or wait for those gates. | #28 |
 
 ## Issue Acceptance Criteria
 
@@ -61,7 +60,7 @@ This audit is intentionally reviewer-facing: it separates what works now from wh
 - [ ] Gap audit and submission packet use the same status buckets.
 - [ ] Every open bounty gap links to a child issue or explicit product decision.
 - [ ] Final submission language distinguishes live MVP evidence from unfinished bounty-critical criteria.
-- [ ] Close only after #23/#24/#26/#28/#30/#38 are completed or deliberately disclosed by the submitter.
+- [ ] Close only after #24/#26/#28 are completed or deliberately disclosed by the submitter.
 
 Learning notes:
 
@@ -82,14 +81,14 @@ Learning notes:
 - **Developer/user must understand**: local Wrangler deployment proved the app could run; GitHub deploy-from-main now proves repeatable release control.
 - **Pitfall**: a successful Worker deploy can still fail evidence collection if the CI parser expects the wrong log shape.
 - **p50 test**: `GET /api/health`, web root, feed, profile, permalink, comment, and claim work after deploy.
-- **p95 test**: run `25212955639` applied remote D1 migrations, deployed the Worker, built the web app against the deployed Worker URL, deployed Pages, and passed public smoke from the deployed commit.
+- **p95 test**: latest run `25216210247` applied remote D1 migrations, deployed the Worker, built the web app against the deployed Worker URL, deployed Pages, and passed public smoke from the deployed commit.
 
-### #23 Complete Extension And Web Capture Journey
+### Closed #23 Complete Extension And Web Capture Journey
 
-- [ ] Web URL capture and extension current-page capture both produce valid annotation payloads.
-- [ ] Selected text is preserved from browser selection to side panel, request payload, and stored annotation.
-- [ ] Media start/end/duration are preserved from real page state to payload and stored annotation.
-- [ ] API/source-link invariants are tested at contract and browser boundaries.
+- [x] Web URL capture and extension current-page capture both produce valid annotation payloads.
+- [x] Selected text is preserved from browser selection to side panel, request payload, and stored annotation.
+- [x] Media start/end/duration are preserved from real page state to payload and stored annotation.
+- [x] API/source-link invariants are tested at contract and browser boundaries.
 
 Learning notes:
 
@@ -146,15 +145,15 @@ Learning notes:
 - **p50 test**: reviewer can run the demo without reading the code.
 - **p95 test**: reviewer can reproduce the highest-risk claims using issue-linked evidence.
 
-### #30 Local Chrome Extension Install And Bounty Smoke Verification
+### Closed #30 Local Chrome Extension Install And Bounty Smoke Verification
 
-- [ ] Rebuilt `dist/extension` loads unpacked after PR #31.
-- [ ] Settings saves production Worker API base without source edits.
-- [ ] Production publish from a real tab creates an annotation visible through API/feed/permalink.
-- [ ] Selected-text context menu proof preserves the exact quote.
-- [ ] Real video/audio proof preserves exact start/end/duration.
-- [ ] >90-second range is blocked in the browser before any production publish request.
-- [ ] Audio/microphone behavior is tested or explicitly tied back to #26.
+- [x] Rebuilt `dist/extension` loads unpacked after PR #31.
+- [x] Settings saves production Worker API base without source edits.
+- [x] Production publish from a real tab creates an annotation visible through API/feed/permalink.
+- [x] Selected-text proof preserves the exact quote.
+- [x] Real media proof preserves exact start/end/duration.
+- [x] >90-second range is blocked in the browser before any production publish request.
+- [x] Audio upload fallback is tested and explicitly tied back to #26.
 
 Learning notes:
 
@@ -163,12 +162,12 @@ Learning notes:
 - **p50 test**: side panel opens, saves API base, captures current tab, publishes one annotation.
 - **p95 test**: context menu selection, media current time, network suppression on invalid duration, and audio fallback are evidenced.
 
-### #38 Reviewer Journey Happy/Sad Paths And Krug Pass
+### Closed #38 Reviewer Journey Happy/Sad Paths And Krug Pass
 
-- [ ] Marketing, feed, signup, local extension install, capture, publish, feed return, comment, follow/engage, and claim steps are documented as one reviewer journey.
-- [ ] The web app exposes the local unpacked-extension path because Chrome Web Store distribution is not part of the MVP.
-- [ ] Auth, extension install, wrong API URL, no selection, over-90 media, audio/R2, and claim-submission recovery states have clear copy and test evidence.
-- [ ] The final demo script follows the same happy/sad paths without requiring improvisation.
+- [x] Marketing, feed, signup, local extension install, capture, publish, feed return, comment, follow/engage, and claim steps are documented as one reviewer journey.
+- [x] The web app exposes the local unpacked-extension path because Chrome Web Store distribution is not part of the MVP.
+- [x] Auth, extension install, wrong API URL, no selection, over-90 media, audio/R2, and claim-submission recovery states have clear copy and test evidence.
+- [x] The final demo script follows the same happy/sad paths without requiring improvisation.
 
 Learning notes:
 
@@ -181,6 +180,4 @@ Learning notes:
 
 - **#24**: Google/X OAuth needs provider apps, secrets, token exchange, user/session persistence, and extension handoff proof.
 - **#26**: R2 is not enabled, audio storage is fallback-only, and owned-media 240p policy is undecided.
-- **#30/#23**: production extension p95 smoke evidence is not yet recorded.
-- **#38**: reviewer journey happy/sad paths and Krug pass are not yet merged into the product/docs.
-- **#28**: external submission should wait for these gates or explicitly disclose them.
+- **#28**: external submission should disclose #24/#26 or wait for those gates.

--- a/docs/submission-packet.md
+++ b/docs/submission-packet.md
@@ -15,13 +15,12 @@ Status buckets used below:
 
 ## Current Submission Status
 
-- **Working deployed MVP**: GitHub Actions deploy-from-main is proven by run `25212955639`; the public Pages and Worker URLs are live; the feed, profile, permalink, source-link, comment/claim intake, text commentary, and API-side 90-second validation have production evidence.
-- **Approved API-level smoke**: `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` is the current public smoke annotation. It proves the production API and web permalink can serve a source-linked 60-second annotation, not that a real Chrome extension captured selected text or media time from a page.
-- **Extension p95 still open**: #30/#23 still need browser evidence for production API-base persistence, exact selected text, exact real media `currentTime`, >90-second no-network rejection, and audio/microphone behavior.
+- **Working deployed MVP**: GitHub Actions deploy-from-main is proven by run `25216210247` from `main` at `afa7e3dda7645c875785546f904798e449339ec2`; the public Pages and Worker URLs are live; the feed, profile, permalink, source-link, comment/claim intake, text commentary, web URL composer, and 90-second validation have production or regression evidence.
+- **Approved API-level smoke**: `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` is the stable public smoke annotation for the production API and web permalink.
+- **Extension p95 complete**: #30 and #23 are closed after PR #43. The unpacked extension p95 smoke proved production API-base persistence, current-tab publish, exact selected-text capture, exact media-time payload seconds, >90-second no-network rejection, stored API reads, and public permalinks.
 - **Auth blocker**: #24 still needs real Google/X apps, secrets, token exchange, user/session creation, and extension handoff. Production correctly fails closed with `auth_not_configured` today.
-- **Audio/240p blocker**: #26 still needs durable recorded-audio storage plus an explicit owned-media 240p/sub-480p policy. Third-party media remains source-linked by reference.
-- **Reviewer journey blocker**: #38 must make the marketing/feed/signup/local-extension/capture/return loop dead simple before filming the demo video.
-- **Final submission requirement**: the human submitter must either wait for #23/#24/#26/#30/#38 or copy the known-limitations language below into the external `annotated.lovable.app` submission.
+- **Audio/240p blocker**: #26 still needs durable recorded-audio storage plus an explicit owned-media 240p/sub-480p policy. Third-party media remains source-linked by reference, and audio upload currently stops at `intent-created`.
+- **Final submission requirement**: the human submitter can submit now with the #24/#26 limitations disclosed, or wait for real OAuth and durable audio/media processing before claiming full bounty coverage.
 
 ## Submission Links
 
@@ -30,11 +29,16 @@ Fill these in immediately before posting to `https://annotated.lovable.app`.
 | Item | Value |
 | --- | --- |
 | Public web URL | `https://annotated-canvas.pages.dev` |
+| Public API base URL | `https://annotated-canvas-api.jaybhagat841.workers.dev` |
 | Public API health URL | `https://annotated-canvas-api.jaybhagat841.workers.dev/api/health` |
+| Reviewer home URL | `https://annotated-canvas.pages.dev/home` |
 | Public feed URL | `https://annotated-canvas.pages.dev/` |
 | Public annotation permalink | `https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` |
+| Extension p95 selected-text permalink | `https://annotated-canvas.pages.dev/a/ann_c6fa89cc-9c1a-4a73-9e37-d6bd08a20ae6` |
+| Extension p95 media-time permalink | `https://annotated-canvas.pages.dev/a/ann_e537cae5-15f0-4dff-808b-219e134a801e` |
 | Public profile URL | `https://annotated-canvas.pages.dev/u/mira` |
 | Source repository | `https://github.com/ChaiWithJai/annotated-canvas` |
+| Extension p95 evidence summary | `https://raw.githubusercontent.com/ChaiWithJai/annotated-canvas/afa7e3dda7645c875785546f904798e449339ec2/docs/audit-assets/extension-smoke-p95/summary.json` |
 | Local web URL | `http://127.0.0.1:5173` |
 | Local API URL | `http://localhost:8787` |
 | Local API health check | `http://localhost:8787/api/health` |
@@ -42,9 +46,12 @@ Fill these in immediately before posting to `https://annotated.lovable.app`.
 
 Public demo routes:
 
+- Reviewer home: `https://annotated-canvas.pages.dev/home`
 - Feed: `https://annotated-canvas.pages.dev/`
 - Profile: `https://annotated-canvas.pages.dev/u/mira`
 - Annotation permalink: `https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`
+- Extension selected-text permalink: `https://annotated-canvas.pages.dev/a/ann_c6fa89cc-9c1a-4a73-9e37-d6bd08a20ae6`
+- Extension media-time permalink: `https://annotated-canvas.pages.dev/a/ann_e537cae5-15f0-4dff-808b-219e134a801e`
 - Removed annotation state: `https://annotated-canvas.pages.dev/a/removed`
 
 Local demo routes:
@@ -91,16 +98,17 @@ Expected service name: `annotated-canvas-api`.
 7. Open the Annotated Canvas side panel from the extension icon.
 8. In Settings, set `API URL` to `https://annotated-canvas-api.jaybhagat841.workers.dev` for production proof, then click `Save settings`.
 9. Use the capture controls to create a text selection or time-range annotation with commentary.
-10. After rebuilding, return to `chrome://extensions` and reload the extension card.
+10. Click `Publish annotation`, then use the Published tab to copy the returned annotation id/permalink.
+11. After rebuilding, return to `chrome://extensions` and reload the extension card.
 
 ## Demo Script
 
 Target length: 8-10 minutes.
 
-1. Open the public web URL at `https://annotated-canvas.pages.dev/`.
-2. Show the public feed, source-domain labels, engagement counts, and `File a claim` button.
+1. Open `https://annotated-canvas.pages.dev/home` and show the reviewer path into the feed and extension install guide.
+2. Show the public feed at `https://annotated-canvas.pages.dev/`, including URL composer, source-domain labels, engagement counts, and `File a claim`.
 3. Open `https://annotated-canvas.pages.dev/u/mira` and show the creator profile and annotation list.
-4. Open `https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` and show the permalink, original source link, commentary, and 60-second clip metadata.
+4. Open `https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` and show the stable smoke permalink, original source link, commentary, and 60-second clip metadata.
 5. Show production auth failing closed until provider secrets exist:
 
    ```bash
@@ -109,15 +117,15 @@ Target length: 8-10 minutes.
    ```
 
 6. Load the unpacked Chrome extension from `dist/extension`.
-7. On a source page, open the side panel and demonstrate current-page capture.
-8. For a text source, select text and add text commentary.
-9. For a media source, enter a start and end time no more than 90 seconds apart and add commentary.
-10. Publish or submit the annotation through the local flow under review.
-11. Return to the web client and show the annotation in feed/permalink form.
+7. In Settings, save the production Worker URL.
+8. For a text source, select text, add text commentary, publish, and show the selected-text permalink `ann_c6fa89cc-9c1a-4a73-9e37-d6bd08a20ae6` as evidence of exact quote preservation.
+9. For a media source, enter a start and end time no more than 90 seconds apart, publish, and show the media-time permalink `ann_e537cae5-15f0-4dff-808b-219e134a801e` as evidence of exact stored seconds.
+10. Enter an over-90 range and show the side panel blocks publish before any production `POST /api/annotations`.
+11. Return to the web client and show the new annotation in feed/permalink form.
 12. Add or show comments and engagement on an annotation.
 13. Click `File a claim`, submit a notice, and show that the claim is recorded without automatically removing the annotation.
 14. Open the original source link from the annotation and confirm the content links back to the source.
-15. Close with the acceptance mapping below and the known blockers list.
+15. Disclose the remaining blockers: real Google/X OAuth credentials and durable audio/owned-media processing.
 
 API publish fallback for reviewers who want payload-level proof:
 
@@ -172,16 +180,16 @@ curl -X POST http://localhost:8787/api/claims \
 
 | Bounty item | Reviewer evidence | Current status |
 | --- | --- | --- |
-| Sidebar Chrome extension | MV3 side panel loaded from `dist/extension`; side panel opens on source pages. | **Working now** locally; production p50/p95 browser proof remains #30/#23. |
-| Highlight and clip text/audio/video from any website | Current-tab context, selected text, media time-range UI/API payloads, and approved production API-level smoke. | **Deployed but limited**; exact selected-text and real media-time browser proof remain #23/#30. |
+| Sidebar Chrome extension | MV3 side panel loaded from `dist/extension`; settings saved the production API base; p95 smoke published current-tab, selected-text, and media-time annotations. | **Working now** with merged p95 evidence from #43. |
+| Highlight and clip text/audio/video from any website | Current-tab context, selected text, media time-range UI/API payloads, approved production API-level smoke, and extension p95 selected-text/media-time proof. | **Working now for text/video references**; recorded audio remains limited until #26. |
 | Add commentary and annotations | Text commentary publish path and API contract. | **Deployed but limited**; recorded audio is fallback-only until #26. |
 | Landing page links back to original source | Approved annotation permalink includes source metadata and original source link. | **Working now** with public permalink smoke `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`. |
 | Public social feed | Feed route and API feed path. | **Working now** with public Worker and Pages smoke. |
 | Users can follow and engage | Feed/profile engagement, follow route, comments, and counts. | **Working now**; include fresh follow/comment proof in final demo. |
 | Account via X or Google | Sign-in buttons call the API and production fails closed when secrets are absent. | **Blocked by human credentials/secrets**; real provider exchange remains #24. |
-| User can enter URL or use current page | Web URL flow and extension current-page capture surface. | **Deployed but limited**; production extension payload proof remains #23/#30. |
-| Prompt for start/end or text section | Extension capture controls and API validation for media duration. | **Deployed but limited**; exact UI-to-payload verification remains #23/#30. |
-| Max clip size 90 seconds | Contracts/API reject over-90-second media references. | **Working now** at contract/API; browser no-network proof remains #30. |
+| User can enter URL or use current page | Web URL composer is present/tested; extension current-page capture p95 proof is merged. | **Working now** for MVP capture paths. |
+| Prompt for start/end or text section | Extension capture controls, selected-text context, and exact UI-to-payload media seconds are evidenced. | **Working now** with p95 extension proof. |
+| Max clip size 90 seconds | Contracts/API reject over-90 media references; extension p95 smoke shows over-90 publish blocked before network. | **Working now**. |
 | Downgrade clip to 240p or below 480p | Third-party media is source-linked by reference; owned uploads need processing policy. | **Not yet implemented**; product/legal decision remains #26. |
 | Text or recorded audio commentary | Text commentary works; audio upload endpoint returns an intent without R2. | **Deployed but limited**; durable audio storage/finalize remains #26. |
 | Users can leave comments | Comment resources and claim/feed docs reflect local completion. | **Working now**; public smoke created `cmt_73c82db2-d4db-4661-b92e-84b12b4e74e7`. |
@@ -191,36 +199,36 @@ curl -X POST http://localhost:8787/api/claims \
 
 ## Open-Issue Acceptance Notes
 
-These notes are the reviewer handoff for the seven open tickets plus the closed Cloudflare dependency. The longer form lives in `docs/bounty-gap-audit.md`.
+These notes are the reviewer handoff for the remaining open tickets plus recently closed evidence gates. The longer form lives in `docs/bounty-gap-audit.md`.
 
 | Issue | Close only when | Learning note | p50 evidence | p95 evidence |
 | --- | --- | --- | --- | --- |
 | #21 Bounty readiness | The status buckets are current and every gap is closed or explicitly disclosed. | A live MVP is not a complete bounty claim. | Public URLs and demo script work. | No bounty-critical limitation is hidden. |
-| Closed #22 Cloudflare deployment | Closed after GitHub Actions deploy-from-main and public smoke passed from run `25212955639`. | Local Wrangler proved capability; CI deploy now proves repeatability. | Public web/API smoke works. | GitHub-deployed smoke passed from head SHA `2963f02d37bff4d862e00027f7774688ff9f5e26`. |
-| #23 Capture journey | Web URL/current-page, selected text, and media time payloads reconcile with stored annotations. | Functional fields are not proof unless payloads match user intent. | One normal annotation publishes. | Exact quote/timecode/source integrity are proven. |
+| Closed #22 Cloudflare deployment | Closed after GitHub Actions deploy-from-main and public smoke passed; latest proof is run `25216210247`. | Local Wrangler proved capability; CI deploy now proves repeatability. | Public web/API smoke works. | GitHub-deployed smoke passed from head SHA `afa7e3dda7645c875785546f904798e449339ec2`. |
+| Closed #23 Capture journey | Closed after PR #43 merged and deploy run `25216210247` passed. | Functional fields are not proof unless payloads match user intent. | One normal annotation publishes. | Exact quote/timecode/source integrity are proven. |
 | #24 OAuth | Google/X provider exchange, sessions, and extension handoff work with real credentials. | Honest not-configured failure is safer than fake account creation. | Signed-out and provider-start behavior is visible. | Invalid/replayed state, logout, and anonymous extension-token rejection are tested. |
 | #26 Audio/240p | Recorded audio persists and owned-media 240p/sub-480p policy is implemented or explicitly excluded. | Third-party references and owned media processing are different rights surfaces. | Text commentary and audio intent behavior are clear. | Stored audio, upload validation, and owned-video rendition policy are enforceable. |
 | #28 Submission package | The external post uses current URLs, smoke IDs, and known limitations. | The packet is a reviewer script plus truth-in-advertising checklist. | Reviewer can run the demo without reading code. | Reviewer can reproduce highest-risk claims from linked evidence. |
-| #30 Extension smoke | Production extension p50 and p95 browser evidence is recorded. | MV3 side-panel proof must happen in Chrome, not only in unit tests. | Side panel saves API base and publishes one annotation. | Selected text, media current time, over-90 no-network rejection, and audio fallback are evidenced. |
-| #38 Reviewer journey | The happy/sad path and Krug pass are merged before filming. | Reviewer onboarding is a product surface, not a doc appendix. | Reviewer can discover, install/use, publish, and return to the feed from one script. | Auth, extension install, invalid range, audio/R2, and claim recovery states are understandable at the point of action. |
+| Closed #30 Extension smoke | Closed after PR #43 merged and deploy run `25216210247` passed. | MV3 side-panel proof must happen in Chrome, not only in unit tests. | Side panel saves API base and publishes one annotation. | Selected text, media current time, over-90 no-network rejection, and audio fallback are evidenced. |
+| Closed #38 Reviewer journey | Closed after the happy/sad path and Krug pass landed. | Reviewer onboarding is a product surface, not a doc appendix. | Reviewer can discover, install/use, publish, and return to the feed from one script. | Auth, extension install, invalid range, audio/R2, and claim recovery states are understandable at the point of action. |
 
 ## Current Open GitHub Issues
 
 Open issue snapshot for `ChaiWithJai/annotated-canvas`:
 
 - #21 `Epic: Bounty gap audit and submission readiness`
-- #23 `Epic: Complete extension and web capture journey`
 - #24 `Epic: Real X/Google auth and extension handoff`
 - #26 `Epic: Audio commentary and 240p media policy`
 - #28 `Task: Prepare final bounty submission package`
-- #30 `Task: Local Chrome extension install and bounty smoke verification`
-- #38 `P0: Codify reviewer journey happy/sad paths and Krug pass before demo video`
 
 Recently completed issue evidence relevant to the packet:
 
 - #22 `Epic: Cloudflare CLI production setup and deployment`
 - #25 `Epic: Public feed, comments, follows, and engagement parity`
 - #27 `Task: Harden claim filing into a reviewable notice workflow`
+- #30 `Task: Local Chrome extension install and bounty smoke verification`
+- #23 `Epic: Complete extension and web capture journey`
+- #38 `P0: Codify reviewer journey happy/sad paths and Krug pass before demo video`
 
 Local Chrome evidence recorded in #30:
 
@@ -231,17 +239,18 @@ Local Chrome evidence recorded in #30:
 - Current-page capture on `http://127.0.0.1:5173/` published into the local Worker API.
 - `GET /api/feed` returned `ann_e496763a-fb93-457b-a3f7-a6659d4f3e9d` with the expected active-tab source and commentary.
 
-Production extension p50/p95 proof still to record:
+Production extension p50/p95 proof recorded in PR #43:
 
-- p50: reload the newly built `dist/extension`, save `https://annotated-canvas-api.jaybhagat841.workers.dev` in Settings, publish one <=90-second annotation from a real tab, and verify the annotation id through production API/feed/permalink evidence.
-- p95 selected text: select an exact quote on a normal HTTPS page, choose `Annotate selected text`, and retain the selected text screenshot, side-panel quote preview, production `POST /api/annotations` payload, response id, and stored annotation proof showing the same quote.
-- p95 media time: seek a real `<video>` or `<audio>` element, record `document.querySelector("video,audio")?.currentTime`, verify side-panel `Start` seeds from that value, publish <=90 seconds, and retain the production payload with exact `start_seconds`, `end_seconds`, and `duration_seconds`.
-- p95 over-90 rejection: enter a range longer than 90 seconds, retain the side-panel error `Clip length must be 90 seconds or less.`, and retain Network/HAR proof that no production `POST /api/annotations` was sent.
-- p95 audio/R2 limitation: record the microphone prompt outcome and the production `POST /api/uploads/audio-commentary` response. Current expected limitation is `upload.status: "intent-created"` rather than `"stored"` because production omits `MEDIA_BUCKET` until #26 enables R2 or another durable audio path.
+- p50 current-tab publish: `ann_a7093956-675f-4580-9d1f-5c85f3d8dff2`, permalink `https://annotated-canvas.pages.dev/a/ann_a7093956-675f-4580-9d1f-5c85f3d8dff2`.
+- p95 selected text: `ann_c6fa89cc-9c1a-4a73-9e37-d6bd08a20ae6` stores the exact quote `This domain is for use in documentation examples without needing permission. Avoid use in operations.`.
+- p95 media time: `ann_e537cae5-15f0-4dff-808b-219e134a801e` stores UI-entered `00:00:05` to `00:00:52` as `start_seconds=5`, `end_seconds=52`, `duration_seconds=47`.
+- p95 over-90 rejection: `00:00:00` to `00:01:31` showed `Clip length must be 90 seconds or less.` with `postCountAfterClick=0`.
+- p95 audio/R2 limitation: production `POST /api/uploads/audio-commentary` returns `upload.status: "intent-created"`; durable storage remains #26.
+- Evidence summary: `https://raw.githubusercontent.com/ChaiWithJai/annotated-canvas/afa7e3dda7645c875785546f904798e449339ec2/docs/audit-assets/extension-smoke-p95/summary.json`.
 
 Production smoke evidence recorded on May 1, 2026:
 
-- GitHub Actions run `25212955639` completed successfully from `main` at `2963f02d37bff4d862e00027f7774688ff9f5e26`.
+- GitHub Actions run `25216210247` completed successfully from `main` at `afa7e3dda7645c875785546f904798e449339ec2`.
 - The run passed typecheck, unit/integration tests, Worker runtime tests, build, Cloudflare production preflight, remote D1 migrations, Worker deploy, production web build, and Pages deploy.
 - `GET https://annotated-canvas-api.jaybhagat841.workers.dev/api/health` returned `200` with `ok: true`, `service: annotated-canvas-api`, and `mode: production`.
 - `GET https://annotated-canvas.pages.dev/`, `/home`, `/u/mira`, and `/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` returned `200`.
@@ -250,22 +259,19 @@ Production smoke evidence recorded on May 1, 2026:
 - `GET /api/me` from the Pages origin returned `401 authentication_required`, which is the expected signed-out state.
 - Google and X auth start endpoints returned `503 auth_not_configured`, listing the missing provider client IDs/secrets.
 - Earlier production API smoke created comment `cmt_73c82db2-d4db-4661-b92e-84b12b4e74e7`, claim notice `claim_36899790-f89f-4add-9744-046b5b46c3f3`, and `POST /api/uploads/audio-commentary` returned `status: intent-created`.
-- Important boundary: this is API-level production smoke. It does not replace #30 browser p95 proof for exact selected text, real media current time, or no-network rejection from the unpacked extension.
+- Important boundary: extension p95 is now recorded, but it does not make real Google/X OAuth or durable audio/owned-media processing complete.
 
 ## Known Blockers Before External Submission
 
-- Public deployment is live and #22 is closed. Do not list Cloudflare deploy-from-main as a remaining blocker.
 - Real Google/X OAuth needs provider client IDs/secrets, callback configuration, token exchange, and production-safe sessions. Tracked by #24.
-- Extension and web capture need final proof that user-entered text/time selections bind exactly to the publish payload. Tracked by #23.
-- Selected-text context menu, real media current-time capture, over-90-second browser validation, and audio commentary remain p95 extension proof gaps. Tracked by #30 and #26.
 - Audio commentary recording/finalize and 240p owned-media policy remain unresolved. Tracked by #26.
 - R2 is not enabled in the Cloudflare account yet. Production omits the R2 binding, so audio upload storage remains blocked by #26.
 - Chrome Web Store distribution is not part of the local MVP; reviewers load `dist/extension` unpacked.
-- Reviewer journey happy/sad paths and the Krug pass must land before filming the demo video. Tracked by #38.
+- Human submission to `https://annotated.lovable.app` remains #28.
 
 Submission language to use if posting before all blockers close:
 
-> Annotated Canvas is live as a source-linked MVP with GitHub-deployed public Pages/Worker URLs, public feed, permalinks, comments, claim filing, text commentary, API-level 90-second validation, and local unpacked Chrome side-panel proof. The current approved public smoke annotation is `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`. The remaining disclosed gaps are real Google/X OAuth credentials and token exchange, production Chrome extension p95 proof for exact selected text/media timing and >90-second no-network rejection, durable recorded-audio storage, owned-media 240p processing policy, and the final reviewer journey/Krug pass before demo filming.
+> Annotated Canvas is live as a source-linked MVP with GitHub-deployed public Pages/Worker URLs, public feed, permalinks, comments, claim filing, text commentary, web URL capture, API-level and extension-level 90-second validation, and unpacked Chrome extension p95 proof for current-tab, selected-text, and media-time capture. The remaining disclosed gaps are real Google/X OAuth credentials and token exchange, durable recorded-audio storage, and owned-media 240p processing policy.
 
 Dependency gate map: `output/reports/gas-town/dependency-gate-map.md`.
 
@@ -280,23 +286,23 @@ External inputs required before this packet can claim full bounty coverage:
 
 - [x] Public web URL is live and replaces the placeholder above.
 - [x] Public API health URL returns OK and replaces the placeholder above.
-- [x] GitHub Actions deploy-from-main is proven by run `25212955639`.
+- [x] GitHub Actions deploy-from-main is proven by run `25216210247`.
 - [x] Public feed, profile, permalink, removed state, and claim flow are smoke-tested.
 - [x] Approved public smoke annotation is current: `ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`.
 - [x] Chrome extension builds with `npm run build:extension`.
 - [x] Unpacked extension loads from `dist/extension` and side panel opens in Chrome.
-- [ ] Extension Settings saves the production Worker URL and publishes through that API base without source edits.
-- [ ] Current-page capture publishes the exact selected text or media time range.
-- [ ] Selected-text context menu proof includes exact quote preservation in the production payload and stored annotation.
-- [ ] Real media current-time proof includes browser `currentTime`, seeded side-panel fields, and exact production payload media seconds.
-- [ ] URL-input capture publishes with the original `source_url`.
+- [x] Extension Settings saves the production Worker URL and publishes through that API base without source edits.
+- [x] Current-page capture publishes exact selected text and media time ranges.
+- [x] Selected-text proof includes exact quote preservation in the production payload and stored annotation.
+- [x] Real media-time proof includes seeded side-panel fields and exact production payload media seconds.
+- [x] URL-input capture composer publishes with the original `source_url` in the web flow.
 - [x] Media duration over 90 seconds is rejected.
-- [ ] Browser p95 proof shows over-90-second extension publish is blocked before any production network request.
+- [x] Browser p95 proof shows over-90-second extension publish is blocked before any production network request.
 - [x] Every public annotation links back to its original source.
 - [x] Comments and engagement are demonstrated on a public annotation.
 - [x] `File a claim` records a notice and does not automatically remove content.
-- [ ] Audio commentary limitation is documented with microphone/upload evidence and the production R2 `intent-created` fallback.
+- [x] Audio commentary limitation is documented with upload evidence and the production `intent-created` fallback.
 - [ ] Demo Google and X auth behavior is documented, or production OAuth is fully configured.
-- [ ] Reviewer journey happy/sad paths and Krug pass from #38 are merged before filming.
+- [x] Reviewer journey happy/sad paths and Krug pass from #38 are merged before filming.
 - [ ] Known limitations are copied into the bounty submission without hiding bounty-critical gaps.
 - [ ] Submission is posted to `https://annotated.lovable.app`.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,6 +1,29 @@
 # Annotated Canvas MVP User Guide
 
-This guide explains how to run the MVP locally, load the Chrome extension as an unpacked extension, publish an annotation, view the public web surfaces, and file a claim.
+This guide explains how to review the live MVP, run it locally, load the Chrome
+extension as an unpacked extension, publish an annotation, view public surfaces,
+and file a claim.
+
+## Production Review URLs
+
+| Item | URL |
+| --- | --- |
+| Web app | `https://annotated-canvas.pages.dev` |
+| Reviewer home | `https://annotated-canvas.pages.dev/home` |
+| API base | `https://annotated-canvas-api.jaybhagat841.workers.dev` |
+| API health | `https://annotated-canvas-api.jaybhagat841.workers.dev/api/health` |
+| Public feed | `https://annotated-canvas.pages.dev/` |
+| Stable smoke permalink | `https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4` |
+| Extension selected-text proof | `https://annotated-canvas.pages.dev/a/ann_c6fa89cc-9c1a-4a73-9e37-d6bd08a20ae6` |
+| Extension media-time proof | `https://annotated-canvas.pages.dev/a/ann_e537cae5-15f0-4dff-808b-219e134a801e` |
+| Public profile | `https://annotated-canvas.pages.dev/u/mira` |
+
+Current production behavior:
+
+- Deploy-from-main is green in GitHub Actions run `25216210247`.
+- The unpacked extension p95 smoke is merged in PR #43 and proves current-tab publish, selected text, media time ranges, over-90 no-network rejection, and public permalinks.
+- Google/X production auth fails closed until provider credentials are installed.
+- Recorded audio storage and owned-media 240p/sub-480p processing remain open; audio upload currently returns `intent-created`.
 
 ## Prerequisites
 
@@ -81,7 +104,7 @@ The extension side panel has four tabs:
 
 - `Capture`: capture a source-linked selected-text or timecode clip, add commentary, save a local draft, or publish.
 - `Drafts`: restore the most recent local smoke-test draft saved in Chrome extension storage.
-- `Published`: points reviewers to the API feed after publish.
+- `Published`: shows the last published annotation id, source, and permalink after publish.
 - `Settings`: switch the API base between localhost and the production Worker without source edits.
 
 The side panel reads the active tab when it can, falls back to the tab URL/title when a content script cannot answer, and publishes through the configured API when `Publish annotation` is clicked. The Settings tab defaults to `http://localhost:8787` and includes a `Production` preset for `https://annotated-canvas-api.jaybhagat841.workers.dev`.
@@ -101,9 +124,13 @@ There are two MVP paths.
 5. Add commentary.
 6. Optionally click `Save draft`; the latest local draft can be restored from `Drafts`.
 7. Click `Publish annotation`.
-8. The button changes from `Publishing...` to `Published`.
+8. Confirm the Published tab shows the returned annotation id and permalink.
 
-This posts to `POST /api/annotations` on the configured API base. For media clips, ranges longer than 90 seconds are blocked in the side panel before a network publish request is sent. For selected text, the context-menu path is `right-click selected text -> Annotate selected text`, then publish from the side panel.
+This posts to `POST /api/annotations` on the configured API base. For media
+clips, reversed, zero-length, and longer-than-90-second ranges are blocked in
+the side panel before a publish request is sent. For selected text, the
+context-menu path is `right-click selected text -> Annotate selected text`, then
+publish from the side panel.
 
 ### Publish Through the Local API
 
@@ -173,21 +200,23 @@ Text clipping uses the same endpoint with `kind: "text"`:
 
 ## View the Feed, Profile, and Permalink
 
-Start the web client with `npm run dev:web`.
+Production routes:
 
-The current web client is a local demo UI with fixture data and route-aware views:
+- Reviewer home: `https://annotated-canvas.pages.dev/home`
+- Feed: `https://annotated-canvas.pages.dev/`
+- Profile: `https://annotated-canvas.pages.dev/u/mira`
+- Stable smoke permalink: `https://annotated-canvas.pages.dev/a/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4`
+- Extension selected-text proof: `https://annotated-canvas.pages.dev/a/ann_c6fa89cc-9c1a-4a73-9e37-d6bd08a20ae6`
+- Extension media-time proof: `https://annotated-canvas.pages.dev/a/ann_e537cae5-15f0-4dff-808b-219e134a801e`
+- Removed annotation state: `https://annotated-canvas.pages.dev/a/removed`
+
+Local routes after `npm run dev:web`:
 
 - Feed: `http://127.0.0.1:5173/`
 - Profile: `http://127.0.0.1:5173/u/mira`
 - Annotation permalink: `http://127.0.0.1:5173/a/ann_video_minimalism`
 - Removed annotation state: `http://127.0.0.1:5173/a/removed`
 - Empty feed state: `http://127.0.0.1:5173/empty`
-
-You can also use the header navigation in the app:
-
-- `Following` opens the feed.
-- `Profile` opens Mira's profile.
-- `Annotation` opens the annotation permalink.
 
 Backend equivalents:
 
@@ -196,6 +225,14 @@ curl http://localhost:8787/api/feed
 curl http://localhost:8787/api/users/mira
 curl http://localhost:8787/api/users/mira/annotations
 curl http://localhost:8787/api/annotations/ann_video_minimalism
+```
+
+Production smoke equivalents:
+
+```bash
+curl https://annotated-canvas-api.jaybhagat841.workers.dev/api/health
+curl https://annotated-canvas-api.jaybhagat841.workers.dev/api/annotations/ann_d586ad40-058a-42c1-b6d7-8e0e691cfae4
+curl https://annotated-canvas-api.jaybhagat841.workers.dev/api/feed
 ```
 
 ## File a Claim
@@ -212,7 +249,9 @@ curl http://localhost:8787/api/annotations/ann_video_minimalism
 4. Enter the reason.
 5. Click `Submit review request`.
 
-The current modal demonstrates the claim workflow in the browser. Use the API flow below when you need a local claim record.
+The claim workflow is review intake. It records a notice and does not
+automatically remove the annotation. Use the API flow below when you need a
+local claim record.
 
 ### File a Claim Through the Local API
 
@@ -234,9 +273,9 @@ curl -X POST http://localhost:8787/api/claims \
 
 The response returns `202 Accepted` with a `claim` object. The API also queues a `claim_notice` job when queue bindings are available.
 
-## Local Auth Behavior
+## Auth Behavior
 
-The MVP allows X and Google auth providers. Local development defaults to demo auth mode.
+Local development defaults to demo auth mode.
 
 ```bash
 curl "http://localhost:8787/api/auth/google/start?return_to=http://127.0.0.1:5173/"
@@ -249,10 +288,33 @@ Real OAuth requires `AUTH_MODE=oauth`, the `DB` and `SESSION_KV` bindings, and p
 
 Production remains intentionally fail-closed until the Google and X OAuth apps are created and `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `X_CLIENT_ID`, and `X_CLIENT_SECRET` are installed as Worker secrets.
 
+## Demo-Video Checklist
+
+- [ ] Start on `https://annotated-canvas.pages.dev/home`.
+- [ ] Show feed, profile, stable smoke permalink, original source link, comments, engagement, and `File a claim`.
+- [ ] Show Google/X auth as fail-closed unless real provider credentials are installed.
+- [ ] Build/reload `dist/extension` in Chrome Developer Mode.
+- [ ] Save `https://annotated-canvas-api.jaybhagat841.workers.dev` in extension Settings.
+- [ ] Publish one <=90-second annotation from a real source tab and show the Published tab permalink.
+- [ ] Show selected-text proof: `ann_c6fa89cc-9c1a-4a73-9e37-d6bd08a20ae6`.
+- [ ] Show media-time proof: `ann_e537cae5-15f0-4dff-808b-219e134a801e`.
+- [ ] Show invalid range blocking before network publish.
+- [ ] File a claim and show the annotation remains visible.
+- [ ] State the remaining OAuth, audio/R2, and owned-media 240p limitations.
+
+## Known Limitations
+
+- Chrome Web Store distribution is not part of the MVP; load `dist/extension` unpacked.
+- Real Google/X OAuth needs provider apps, secrets, callback configuration, and production smoke.
+- Recorded audio commentary is fallback-only until durable storage/finalize and playback/reference behavior are implemented.
+- Owned-media 240p/sub-480p processing remains a product/legal and implementation decision; third-party media is source-linked by reference.
+
 ## Troubleshooting
 
 - If Chrome says the extension is invalid, rebuild with `npm run build:extension` and load `dist/extension`, not `apps/extension`.
 - If the side panel does not update after code changes, rebuild and reload the extension from `chrome://extensions`.
 - If the web client cannot call the API, confirm the API is on `http://localhost:8787` and the web app is on `http://127.0.0.1:5173`; `APP_ORIGIN` in `apps/api/wrangler.jsonc` is set for that local origin.
+- If production publish uses the wrong backend, open extension Settings and save the Production preset.
 - If `POST /api/annotations` returns `428`, add an `Idempotency-Key` header with at least 8 characters.
 - If a claim returns `404`, create or use an existing annotation id first.
+- If Google/X sign-in reports missing provider config in production, that is expected until #24 credentials and smoke are complete.


### PR DESCRIPTION
## Summary
- Updates the canonical bounty gap audit, submission packet, and user guide after PR #43.
- Marks #23/#30/#38 as closed evidence gates and keeps #24/#26/#28 as the remaining submission blockers.
- Adds p95 extension evidence links and demo-video checklist updates for selected text, media time, over-90 no-network rejection, and audio fallback.

## Verification
- Checked docs for stale #23/#30/#38 p95 blocker language.
- `git diff --no-index --check` produced no whitespace warnings for the updated docs.

Refs #28
Refs #21
