### PR TITLE
Harden audio commentary storage contracts

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -27,11 +27,27 @@ async function body(response: Response) {
 function createSessionKv(seed: Record<string, string> = {}) {
   const store = new Map(Object.entries(seed));
   const kv = {
-    async get(key: string) {
-      return store.get(key) ?? null;
+    async get(key: string, type?: "text" | "json" | "arrayBuffer" | "stream") {
+      const value = store.get(key) ?? null;
+      if (value === null) return null;
+      if (type === "arrayBuffer") {
+        return new TextEncoder().encode(value).buffer;
+      }
+      if (type === "json") {
+        return JSON.parse(value);
+      }
+      return value;
     },
     async put(key: string, value: string | ArrayBuffer | ArrayBufferView | ReadableStream) {
-      store.set(key, String(value));
+      if (typeof value === "string") {
+        store.set(key, value);
+      } else if (value instanceof ArrayBuffer) {
+        store.set(key, new TextDecoder().decode(value));
+      } else if (ArrayBuffer.isView(value)) {
+        store.set(key, new TextDecoder().decode(value));
+      } else {
+        store.set(key, String(value));
+      }
     },
     async delete(key: string) {
       store.delete(key);
@@ -790,8 +806,189 @@ describe("API router regression coverage", () => {
     const upload = AudioCommentaryUploadResponseSchema.parse(payload.upload);
     expect(response.status).toBe(200);
     expect(upload.status).toBe("intent-created");
+    expect(upload.storage).toBe("kv");
     expect(upload.max_bytes).toBe(AUDIO_COMMENTARY_MAX_BYTES);
-    expect(upload.r2_key).toMatch(/^audio-commentary\/upl_.+\.webm$/);
+    expect(upload.kv_key).toMatch(/^media_blob:upl_.+/);
+  });
+
+  it("stores audio commentary durably in KV when R2 is unavailable", async () => {
+    const sessionKv = createSessionKv();
+    const response = await handleRequest(
+      request("/api/uploads/audio-commentary", {
+        method: "POST",
+        headers: {
+          "Content-Type": "audio/webm"
+        },
+        body: "audio-bytes"
+      }),
+      { ...env, SESSION_KV: sessionKv },
+      { repository, jobs }
+    );
+
+    const payload = await body(response);
+    const upload = AudioCommentaryUploadResponseSchema.parse(payload.upload);
+    expect(response.status).toBe(200);
+    expect(upload.status).toBe("stored");
+    expect(upload.storage).toBe("kv");
+    expect(upload.byte_length).toBeGreaterThan(0);
+    expect(await sessionKv.get(`media_asset:${upload.asset_id}`)).toContain("\"status\":\"stored\"");
+  });
+
+  it("serves stored KV audio commentary bytes by asset id", async () => {
+    const sessionKv = createSessionKv();
+    const uploadResponse = await handleRequest(
+      request("/api/uploads/audio-commentary", {
+        method: "POST",
+        headers: {
+          "Content-Type": "audio/webm"
+        },
+        body: "audio-bytes"
+      }),
+      { ...env, SESSION_KV: sessionKv },
+      { repository, jobs }
+    );
+    const upload = AudioCommentaryUploadResponseSchema.parse((await body(uploadResponse)).upload);
+
+    const response = await handleRequest(
+      request(`/api/uploads/audio-commentary/${upload.asset_id}`),
+      { ...env, SESSION_KV: sessionKv },
+      { repository, jobs }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("audio/webm");
+    expect(await response.text()).toBe("audio-bytes");
+  });
+
+  it("rejects unsupported audio commentary content types", async () => {
+    const response = await handleRequest(
+      request("/api/uploads/audio-commentary", {
+        method: "POST",
+        headers: {
+          "Content-Type": "text/plain"
+        },
+        body: "not-audio"
+      }),
+      { ...env, SESSION_KV: createSessionKv() },
+      { repository, jobs }
+    );
+
+    const payload = await body(response);
+    expect(response.status).toBe(415);
+    expect(payload.error.code).toBe("unsupported_audio_type");
+  });
+
+  it("rejects arbitrary audio asset ids before annotation publish", async () => {
+    const response = await handleRequest(
+      request("/api/annotations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": "publish-key-unknown-audio-asset"
+        },
+        body: JSON.stringify({
+          clip: fixtures.annotations[0].clip,
+          commentary: {
+            kind: "audio",
+            text: "Unknown upload metadata should fail.",
+            audio_asset_id: "upl_missing"
+          },
+          visibility: "public",
+          client_context: { surface: "extension", capture_method: "media-timecode" }
+        })
+      }),
+      { ...env, SESSION_KV: createSessionKv() },
+      { repository, jobs }
+    );
+
+    const payload = await body(response);
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe("audio_asset_not_found");
+  });
+
+  it("rejects unfinalized audio asset metadata before annotation publish", async () => {
+    const sessionKv = createSessionKv({
+      "media_asset:upl_incomplete": JSON.stringify({
+        id: "upl_incomplete",
+        asset_id: "upl_incomplete",
+        kind: "audio-commentary",
+        storage: "kv",
+        kv_key: "media_blob:upl_incomplete",
+        max_bytes: AUDIO_COMMENTARY_MAX_BYTES,
+        status: "stored"
+      })
+    });
+
+    const response = await handleRequest(
+      request("/api/annotations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": "publish-key-unfinalized-audio-asset"
+        },
+        body: JSON.stringify({
+          clip: fixtures.annotations[0].clip,
+          commentary: {
+            kind: "audio",
+            text: "Incomplete upload metadata should fail.",
+            audio_asset_id: "upl_incomplete"
+          },
+          visibility: "public",
+          client_context: { surface: "extension", capture_method: "media-timecode" }
+        })
+      }),
+      { ...env, SESSION_KV: sessionKv },
+      { repository, jobs }
+    );
+
+    const payload = await body(response);
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe("audio_asset_not_finalized");
+  });
+
+  it("publishes audio commentary after the uploaded asset is stored", async () => {
+    const sessionKv = createSessionKv();
+    const uploadResponse = await handleRequest(
+      request("/api/uploads/audio-commentary", {
+        method: "POST",
+        headers: {
+          "Content-Type": "audio/webm"
+        },
+        body: "audio-bytes"
+      }),
+      { ...env, SESSION_KV: sessionKv },
+      { repository, jobs }
+    );
+    const upload = AudioCommentaryUploadResponseSchema.parse((await body(uploadResponse)).upload);
+
+    const response = await handleRequest(
+      request("/api/annotations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": "publish-key-known-audio-asset"
+        },
+        body: JSON.stringify({
+          clip: fixtures.annotations[0].clip,
+          commentary: {
+            kind: "audio",
+            text: "Stored audio commentary.",
+            audio_asset_id: upload.asset_id
+          },
+          visibility: "public",
+          client_context: { surface: "extension", capture_method: "media-timecode" }
+        })
+      }),
+      { ...env, SESSION_KV: sessionKv },
+      { repository, jobs }
+    );
+
+    const payload = await body(response);
+    expect(response.status).toBe(201);
+    expect(payload.annotation.commentary).toMatchObject({
+      kind: "audio",
+      audio_asset_id: upload.asset_id
+    });
   });
 
   it("keeps owned-video uploads as intent-only until 240p processing is implemented", async () => {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,5 +1,7 @@
 import {
+  AUDIO_COMMENTARY_MAX_BYTES,
   AnnotationCreateSchema,
+  AudioCommentaryUploadResponseSchema,
   AuthProviderSchema,
   ClaimCreateSchema,
   ClaimEventCreateSchema,
@@ -48,6 +50,8 @@ const DEMO_USER = {
   handle: "mira",
   display_name: "Mira Chen"
 };
+
+const ALLOWED_AUDIO_COMMENTARY_TYPES = new Set(["audio/webm", "audio/mpeg", "audio/mp4", "audio/ogg", "audio/wav"]);
 
 const defaultRepositories = new Map<string, InMemoryRepository>();
 
@@ -138,6 +142,54 @@ function requireIdempotencyKey(request: Request): string | Response {
     return new Response("missing idempotency key", { status: 428 });
   }
   return key;
+}
+
+function normalizeContentType(value: string | null): string {
+  return (value ?? "application/octet-stream").split(";")[0]?.trim().toLowerCase() || "application/octet-stream";
+}
+
+async function findAudioCommentaryAsset(env: Env, audioAssetId: string) {
+  const metadata = await env.SESSION_KV?.get(`media_asset:${audioAssetId}`);
+  if (!metadata) return null;
+
+  try {
+    const parsed = AudioCommentaryUploadResponseSchema.safeParse(JSON.parse(metadata));
+    if (!parsed.success || parsed.data.asset_id !== audioAssetId || parsed.data.status !== "stored") return null;
+
+    return parsed.data;
+  } catch {
+    return null;
+  }
+}
+
+async function validateAudioCommentaryAsset(env: Env, request: Request, audioAssetId: string): Promise<Response | null> {
+  if (!env.SESSION_KV) {
+    return error(env, 503, "audio_storage_not_configured", "Audio commentary assets require durable storage metadata.", {
+      missing: ["SESSION_KV"]
+    }, request);
+  }
+
+  const metadata = await env.SESSION_KV.get(`media_asset:${audioAssetId}`);
+  if (!metadata) {
+    return error(env, 400, "audio_asset_not_found", "Audio commentary must reference a finalized uploaded asset.", {
+      audio_asset_id: audioAssetId
+    }, request);
+  }
+
+  try {
+    const asset = await findAudioCommentaryAsset(env, audioAssetId);
+    if (!asset) {
+      return error(env, 400, "audio_asset_not_finalized", "Audio commentary asset is not finalized.", {
+        audio_asset_id: audioAssetId
+      }, request);
+    }
+  } catch {
+    return error(env, 400, "audio_asset_not_finalized", "Audio commentary asset is not finalized.", {
+      audio_asset_id: audioAssetId
+    }, request);
+  }
+
+  return null;
 }
 
 function queueJob(type: QueueJob["type"], ids: Partial<Pick<QueueJob, "annotation_id" | "claim_id">>): QueueJob {
@@ -734,6 +786,11 @@ export async function handleRequest(request: Request, env: Env, services = makeS
       return error(env, 400, "invalid_annotation", "Annotation payload failed validation.", parsed.error.flatten());
     }
 
+    if (parsed.data.commentary.kind === "audio") {
+      const audioAssetError = await validateAudioCommentaryAsset(env, request, parsed.data.commentary.audio_asset_id);
+      if (audioAssetError) return audioAssetError;
+    }
+
     const annotation = await services.repository.publishAnnotation(parsed.data, idempotencyKey);
     await services.jobs.send(queueJob("feed_fanout", { annotation_id: annotation.id }));
     return json(env, { annotation }, { status: 201 });
@@ -862,13 +919,155 @@ export async function handleRequest(request: Request, env: Env, services = makeS
     }
   }
 
+  const audioCommentaryMatch = url.pathname.match(/^\/api\/uploads\/audio-commentary\/([^/]+)$/);
+  if (audioCommentaryMatch && request.method === "GET") {
+    if (!env.SESSION_KV) {
+      return error(env, 503, "audio_storage_not_configured", "Audio commentary assets require durable storage metadata.", {
+        missing: ["SESSION_KV"]
+      }, request);
+    }
+
+    const asset = await findAudioCommentaryAsset(env, audioCommentaryMatch[1]);
+    if (!asset) {
+      return error(env, 404, "audio_asset_not_found", "No stored audio commentary exists for that asset id.", {
+        audio_asset_id: audioCommentaryMatch[1]
+      }, request);
+    }
+
+    let bytes: ArrayBuffer | null = null;
+    if (asset.storage === "r2") {
+      if (!env.MEDIA_BUCKET || !asset.r2_key) {
+        return error(env, 503, "audio_storage_not_configured", "Audio commentary R2 storage is not configured.", {
+          missing: ["MEDIA_BUCKET"]
+        }, request);
+      }
+      const object = await env.MEDIA_BUCKET.get(asset.r2_key);
+      bytes = object ? await object.arrayBuffer() : null;
+    } else if (asset.kv_key) {
+      bytes = await env.SESSION_KV.get(asset.kv_key, "arrayBuffer");
+    }
+
+    if (!bytes) {
+      return error(env, 404, "audio_asset_not_found", "Stored audio commentary bytes were not found.", {
+        audio_asset_id: audioCommentaryMatch[1]
+      }, request);
+    }
+
+    return new Response(bytes, {
+      headers: {
+        "Content-Type": asset.content_type ?? "audio/webm",
+        "Content-Length": String(bytes.byteLength),
+        "Cache-Control": "private, max-age=300",
+        ...corsHeaders(env, request)
+      }
+    });
+  }
+
   if (url.pathname === "/api/uploads/audio-commentary" && request.method === "POST") {
     const id = `upl_${crypto.randomUUID()}`;
     const key = `audio-commentary/${id}.webm`;
-    if (env.MEDIA_BUCKET && request.body) {
-      await env.MEDIA_BUCKET.put(key, request.body, {
+    const contentType = normalizeContentType(request.headers.get("Content-Type"));
+    const declaredLength = Number(request.headers.get("Content-Length") ?? "0");
+    if (!ALLOWED_AUDIO_COMMENTARY_TYPES.has(contentType)) {
+      return error(env, 415, "unsupported_audio_type", "Audio commentary must be a supported browser audio type.", {
+        allowed: Array.from(ALLOWED_AUDIO_COMMENTARY_TYPES),
+        received: contentType
+      }, request);
+    }
+
+    if (declaredLength > AUDIO_COMMENTARY_MAX_BYTES) {
+      return error(env, 413, "audio_too_large", "Audio commentary exceeds the maximum upload size.", {
+        max_bytes: AUDIO_COMMENTARY_MAX_BYTES
+      }, request);
+    }
+
+    if (!request.body) {
+      return json(env, {
+        upload: {
+          id,
+          asset_id: id,
+          kind: "audio-commentary",
+          storage: "kv",
+          kv_key: `media_blob:${id}`,
+          max_bytes: AUDIO_COMMENTARY_MAX_BYTES,
+          status: "intent-created"
+        }
+      });
+    }
+
+    const bytes = await request.arrayBuffer();
+    if (bytes.byteLength === 0) {
+      return error(env, 400, "empty_audio_upload", "Audio commentary upload cannot be empty.", {}, request);
+    }
+
+    if (bytes.byteLength > AUDIO_COMMENTARY_MAX_BYTES) {
+      return error(env, 413, "audio_too_large", "Audio commentary exceeds the maximum upload size.", {
+        max_bytes: AUDIO_COMMENTARY_MAX_BYTES
+      }, request);
+    }
+
+    if (env.MEDIA_BUCKET) {
+      await env.MEDIA_BUCKET.put(key, bytes, {
         httpMetadata: {
-          contentType: request.headers.get("Content-Type") ?? "audio/webm"
+          contentType
+        }
+      });
+
+      if (env.SESSION_KV) {
+        await env.SESSION_KV.put(`media_asset:${id}`, JSON.stringify({
+          id,
+          asset_id: id,
+          kind: "audio-commentary",
+          storage: "r2",
+          r2_key: key,
+          content_type: contentType,
+          byte_length: bytes.byteLength,
+          max_bytes: AUDIO_COMMENTARY_MAX_BYTES,
+          status: "stored"
+        }));
+      }
+
+      return json(env, {
+        upload: {
+          id,
+          asset_id: id,
+          kind: "audio-commentary",
+          storage: "r2",
+          r2_key: key,
+          content_type: contentType,
+          byte_length: bytes.byteLength,
+          max_bytes: AUDIO_COMMENTARY_MAX_BYTES,
+          status: "stored"
+        }
+      });
+    }
+
+    if (env.SESSION_KV) {
+      const kvKey = `media_blob:${id}`;
+      await env.SESSION_KV.put(kvKey, bytes);
+      await env.SESSION_KV.put(`media_asset:${id}`, JSON.stringify({
+        id,
+        asset_id: id,
+        kind: "audio-commentary",
+        storage: "kv",
+        kv_key: kvKey,
+        content_type: contentType,
+        byte_length: bytes.byteLength,
+        max_bytes: AUDIO_COMMENTARY_MAX_BYTES,
+        status: "stored"
+      }));
+
+      return json(env, {
+        upload: {
+          id,
+          asset_id: id,
+          kind: "audio-commentary",
+          storage: "kv",
+          kv_key: kvKey,
+          content_type: contentType,
+          byte_length: bytes.byteLength,
+          max_bytes: AUDIO_COMMENTARY_MAX_BYTES,
+          status: "stored"
         }
       });
     }
@@ -878,10 +1077,10 @@ export async function handleRequest(request: Request, env: Env, services = makeS
         id,
         asset_id: id,
         kind: "audio-commentary",
-        storage: "r2",
-        r2_key: key,
-        max_bytes: 25 * 1024 * 1024,
-        status: env.MEDIA_BUCKET && request.body ? "stored" : "intent-created"
+        storage: "kv",
+        kv_key: `media_blob:${id}`,
+        max_bytes: AUDIO_COMMENTARY_MAX_BYTES,
+        status: "intent-created"
       }
     });
   }

--- a/apps/api/wrangler.production.jsonc
+++ b/apps/api/wrangler.production.jsonc
@@ -29,6 +29,12 @@
       "id": "46ef271ad63242ea86c3a657f05fa556"
     }
   ],
+  "r2_buckets": [
+    {
+      "binding": "MEDIA_BUCKET",
+      "bucket_name": "annotated-canvas-media"
+    }
+  ],
   "queues": {
     "producers": [
       {

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -113,7 +113,7 @@ describe("contract validation", () => {
     expect(result.success).toBe(false);
   });
 
-  it("documents the current audio upload response as intent or stored, not finalized", () => {
+  it("accepts R2-backed audio upload metadata", () => {
     const result = AudioCommentaryUploadResponseSchema.parse({
       id: "upl_audio",
       asset_id: "upl_audio",
@@ -125,6 +125,52 @@ describe("contract validation", () => {
     });
 
     expect(result.status).toBe("intent-created");
+  });
+
+  it("accepts KV-backed audio upload metadata when R2 is unavailable", () => {
+    const result = AudioCommentaryUploadResponseSchema.parse({
+      id: "upl_audio",
+      asset_id: "upl_audio",
+      kind: "audio-commentary",
+      storage: "kv",
+      kv_key: "media_blob:upl_audio",
+      content_type: "audio/webm",
+      byte_length: 512,
+      max_bytes: AUDIO_COMMENTARY_MAX_BYTES,
+      status: "stored"
+    });
+
+    expect(result.storage).toBe("kv");
+    expect(result.status).toBe("stored");
+  });
+
+  it("rejects stored audio upload metadata without finalized byte details", () => {
+    const result = AudioCommentaryUploadResponseSchema.safeParse({
+      id: "upl_audio",
+      asset_id: "upl_audio",
+      kind: "audio-commentary",
+      storage: "kv",
+      kv_key: "media_blob:upl_audio",
+      max_bytes: AUDIO_COMMENTARY_MAX_BYTES,
+      status: "stored"
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects KV-backed audio upload metadata without a KV blob key", () => {
+    const result = AudioCommentaryUploadResponseSchema.safeParse({
+      id: "upl_audio",
+      asset_id: "upl_audio",
+      kind: "audio-commentary",
+      storage: "kv",
+      content_type: "audio/webm",
+      byte_length: 512,
+      max_bytes: AUDIO_COMMENTARY_MAX_BYTES,
+      status: "stored"
+    });
+
+    expect(result.success).toBe(false);
   });
 
   it("documents owned-video uploads as intent-only until 240p processing exists", () => {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -210,10 +210,48 @@ export const AudioCommentaryUploadResponseSchema = z
     id: z.string().min(1),
     asset_id: z.string().min(1),
     kind: z.literal("audio-commentary"),
-    storage: z.literal("r2"),
-    r2_key: z.string().min(1),
+    storage: z.enum(["r2", "kv"]),
+    r2_key: z.string().min(1).optional(),
+    kv_key: z.string().min(1).optional(),
+    content_type: z.string().min(1).optional(),
+    byte_length: z.number().int().nonnegative().optional(),
     max_bytes: z.literal(AUDIO_COMMENTARY_MAX_BYTES),
     status: z.enum(["intent-created", "stored"])
+  })
+  .superRefine((upload, ctx) => {
+    if (upload.storage === "r2" && !upload.r2_key) {
+      ctx.addIssue({
+        code: "custom",
+        message: "r2_key is required for R2-backed audio uploads",
+        path: ["r2_key"]
+      });
+    }
+
+    if (upload.storage === "kv" && !upload.kv_key) {
+      ctx.addIssue({
+        code: "custom",
+        message: "kv_key is required for KV-backed audio uploads",
+        path: ["kv_key"]
+      });
+    }
+
+    if (upload.status === "stored") {
+      if (!upload.content_type) {
+        ctx.addIssue({
+          code: "custom",
+          message: "content_type is required for stored audio uploads",
+          path: ["content_type"]
+        });
+      }
+
+      if (typeof upload.byte_length !== "number" || upload.byte_length <= 0) {
+        ctx.addIssue({
+          code: "custom",
+          message: "byte_length must be positive for stored audio uploads",
+          path: ["byte_length"]
+        });
+      }
+    }
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- stores audio commentary bytes in KV when R2 is unavailable, while preserving R2 as the preferred backend when MEDIA_BUCKET is bound
- validates audio upload metadata before publishing audio annotations and adds a GET endpoint to retrieve stored audio bytes by asset id
- adds the production R2 bucket binding for annotated-canvas-media so deploys attach it after R2 is enabled

## Verification
- npm run test:node -- packages/contracts/src/index.test.ts apps/api/src/app.test.ts
- npm test
- npm run typecheck
- npm run build
- git diff --check

## Notes
Cloudflare R2 remains blocked at the account-level dashboard step. Wrangler still returns code 10042 until R2 is enabled in the dashboard.