### PR TITLE
Complete OAuth extension handoff plumbing

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -585,6 +585,65 @@ describe("API router regression coverage", () => {
     });
   });
 
+  it("accepts a bearer extension token for /api/me and attributes extension publishes to that user", async () => {
+    const sessionKv = createSessionKv({
+      "extension_token:ext_valid": JSON.stringify({
+        user_id: "usr_oauth",
+        provider: "google",
+        session_id: "ses_valid",
+        handle: "oauth-user",
+        display_name: "OAuth User"
+      })
+    });
+    const oauthEnv: Env = {
+      ...env,
+      AUTH_MODE: "oauth",
+      SESSION_KV: sessionKv
+    };
+
+    const me = await handleRequest(
+      request("/api/me", {
+        headers: {
+          Authorization: "Bearer ext_valid"
+        }
+      }),
+      oauthEnv,
+      { repository, jobs }
+    );
+    expect(me.status).toBe(200);
+    expect((await body(me)).user).toMatchObject({
+      id: "usr_oauth",
+      handle: "oauth-user"
+    });
+
+    const response = await handleRequest(
+      request("/api/annotations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": "publish-key-extension-auth",
+          Authorization: "Bearer ext_valid"
+        },
+        body: JSON.stringify({
+          clip: fixtures.annotations[1].clip,
+          commentary: { kind: "text", text: "Authenticated extension publish." },
+          visibility: "public",
+          client_context: { surface: "extension", capture_method: "selection" }
+        })
+      }),
+      oauthEnv,
+      { repository, jobs }
+    );
+
+    const payload = await body(response);
+    expect(response.status).toBe(201);
+    expect(payload.annotation.author).toMatchObject({
+      id: "usr_oauth",
+      handle: "oauth-user",
+      display_name: "OAuth User"
+    });
+  });
+
   it("deletes the session on logout when session KV is available", async () => {
     const sessionKv = createSessionKv({
       "session:ses_valid": JSON.stringify({
@@ -638,6 +697,23 @@ describe("API router regression coverage", () => {
     expect(callback.status).toBe(302);
     expect(callback.headers.get("Location")).toBe("https://annotated-canvas.pages.dev");
     expect(callback.headers.get("Set-Cookie")).toContain("SameSite=None; Secure");
+  });
+
+  it("allows chrome-extension return_to URLs for extension OAuth handoff without opening arbitrary web redirects", async () => {
+    const productionEnv: Env = {
+      ...env,
+      APP_ORIGIN: "https://annotated-canvas.pages.dev",
+      SESSION_KV: createSessionKv()
+    };
+
+    const start = await body(
+      await handleRequest(
+        request("/api/auth/google/start?return_to=chrome-extension://extension-id/sidepanel.html?auth=1"),
+        productionEnv,
+        { repository, jobs }
+      )
+    );
+    expect(start.authorization_url).toContain("return_to=chrome-extension%3A%2F%2Fextension-id%2Fsidepanel.html%3Fauth%3D1");
   });
 
   it("serves p50 user profile, annotations, and follow contract routes", async () => {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -290,6 +290,7 @@ function parseAuthSession(value: string): AuthSession | null {
 
     return {
       user_id: parsed.user_id,
+      session_id: typeof parsed.session_id === "string" ? parsed.session_id : undefined,
       provider: parsed.provider === "x" || parsed.provider === "google" ? parsed.provider : undefined,
       handle: typeof parsed.handle === "string" ? parsed.handle : undefined,
       display_name: typeof parsed.display_name === "string" ? parsed.display_name : undefined,
@@ -300,22 +301,56 @@ function parseAuthSession(value: string): AuthSession | null {
   }
 }
 
+function bearerToken(request: Request): string | null {
+  const authorization = request.headers.get("Authorization");
+  const match = authorization?.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || null;
+}
+
+async function readSessionById(env: Env, sessionId: string): Promise<AuthSession | null> {
+  const sessionPayload = await env.SESSION_KV?.get(`session:${sessionId}`);
+  if (!sessionPayload) return null;
+  return parseAuthSession(sessionPayload);
+}
+
+async function readExtensionSession(request: Request, env: Env): Promise<AuthSession | null> {
+  const token = bearerToken(request);
+  if (!token || !env.SESSION_KV) return null;
+
+  const tokenPayload = await env.SESSION_KV.get(`extension_token:${token}`);
+  if (!tokenPayload) return null;
+
+  const session = parseAuthSession(tokenPayload);
+  return session ? { ...session, session_id: session.session_id ?? token } : null;
+}
+
+async function optionalAuthSession(request: Request, env: Env): Promise<AuthSession | null> {
+  if (!env.SESSION_KV) return null;
+
+  const extensionSession = await readExtensionSession(request, env);
+  if (extensionSession) return extensionSession;
+
+  const sessionId = parseCookie(request, "annotated_session");
+  if (!sessionId) return null;
+
+  const session = await readSessionById(env, sessionId);
+  return session ? { ...session, session_id: sessionId } : null;
+}
+
 async function requireOAuthSession(request: Request, env: Env): Promise<AuthSession | Response> {
   if (!env.SESSION_KV) {
     return error(env, 503, "auth_not_configured", "OAuth sessions require SESSION_KV.", {}, request);
   }
+
+  const extensionSession = await readExtensionSession(request, env);
+  if (extensionSession) return extensionSession;
 
   const sessionId = parseCookie(request, "annotated_session");
   if (!sessionId) {
     return error(env, 401, "authentication_required", "A valid session is required.", {}, request);
   }
 
-  const sessionPayload = await env.SESSION_KV.get(`session:${sessionId}`);
-  if (!sessionPayload) {
-    return error(env, 401, "authentication_required", "A valid session is required.", {}, request);
-  }
-
-  const session = parseAuthSession(sessionPayload);
+  const session = await readSessionById(env, sessionId);
   if (!session) {
     return error(env, 401, "authentication_required", "A valid session is required.", {}, request);
   }
@@ -329,7 +364,7 @@ function resolveReturnTo(env: Env, rawReturnTo: string | null): string {
 
   try {
     const candidate = new URL(rawReturnTo, appOrigin);
-    if (candidate.origin === appOrigin) return candidate.toString();
+    if (candidate.origin === appOrigin || candidate.protocol === "chrome-extension:") return candidate.toString();
   } catch {
     return appOrigin;
   }
@@ -791,7 +826,12 @@ export async function handleRequest(request: Request, env: Env, services = makeS
       if (audioAssetError) return audioAssetError;
     }
 
-    const annotation = await services.repository.publishAnnotation(parsed.data, idempotencyKey);
+    const session = await optionalAuthSession(request, env);
+    const annotation = await services.repository.publishAnnotation(
+      parsed.data,
+      idempotencyKey,
+      session ? userFromSession(session) : undefined
+    );
     await services.jobs.send(queueJob("feed_fanout", { annotation_id: annotation.id }));
     return json(env, { annotation }, { status: 201 });
   }

--- a/apps/api/src/repository.ts
+++ b/apps/api/src/repository.ts
@@ -37,6 +37,10 @@ function cloneAnnotation(annotation: AnnotationResource): AnnotationResource {
   return structuredClone(annotation);
 }
 
+function authorOrCurrentUser(author?: AnnotationResource["author"]): AnnotationResource["author"] {
+  return author ?? fixtures.currentUser;
+}
+
 export class InMemoryRepository implements Repository {
   private readonly appOrigin: string;
   private annotations = new Map<string, AnnotationResource>();
@@ -93,19 +97,24 @@ export class InMemoryRepository implements Repository {
       .map(cloneAnnotation);
   }
 
-  async publishAnnotation(input: AnnotationCreate, idempotencyKey: string): Promise<AnnotationResource> {
+  async publishAnnotation(
+    input: AnnotationCreate,
+    idempotencyKey: string,
+    author?: AnnotationResource["author"]
+  ): Promise<AnnotationResource> {
     const existingId = this.idempotency.get(`publish:${idempotencyKey}`);
     if (existingId) {
       const existing = await this.findAnnotation(existingId);
       if (existing) return existing;
     }
 
+    const resolvedAuthor = authorOrCurrentUser(author);
     const id = `ann_${crypto.randomUUID()}`;
     const timestamp = now();
     const annotation: AnnotationResource = {
       id,
-      author_id: fixtures.currentUser.id,
-      author: fixtures.currentUser,
+      author_id: resolvedAuthor.id,
+      author: resolvedAuthor,
       clip: input.clip,
       commentary: input.commentary,
       visibility: input.visibility,
@@ -494,7 +503,11 @@ export class D1Repository implements Repository {
     return result.results.map((row) => annotationFromRow(row, this.appOrigin));
   }
 
-  async publishAnnotation(input: AnnotationCreate, idempotencyKey: string): Promise<AnnotationResource> {
+  async publishAnnotation(
+    input: AnnotationCreate,
+    idempotencyKey: string,
+    author?: AnnotationResource["author"]
+  ): Promise<AnnotationResource> {
     const existing = await this.db
       .prepare("SELECT resource_id FROM mutation_idempotency_keys WHERE scope = 'publish' AND idempotency_key = ?")
       .bind(idempotencyKey)
@@ -563,7 +576,7 @@ export class D1Repository implements Repository {
       )
       .bind(
         annotationId,
-        this.viewerId,
+        author?.id ?? this.viewerId,
         clipId,
         input.commentary.kind,
         input.commentary.kind === "text" ? input.commentary.text : (input.commentary.text ?? null),

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -69,7 +69,11 @@ export interface Repository {
   findAnnotation(id: string): Promise<AnnotationResource | null>;
   findUserByHandle(handle: string): Promise<UserResource | null>;
   listUserAnnotations(handle: string): Promise<AnnotationResource[]>;
-  publishAnnotation(input: AnnotationCreate, idempotencyKey: string): Promise<AnnotationResource>;
+  publishAnnotation(
+    input: AnnotationCreate,
+    idempotencyKey: string,
+    author?: AnnotationResource["author"]
+  ): Promise<AnnotationResource>;
   createClaim(input: ClaimCreate, idempotencyKey?: string): Promise<ClaimResource>;
   findClaim(id: string): Promise<ClaimResource | null>;
   listClaimEvents(claimId: string): Promise<ClaimEventResource[]>;

--- a/apps/extension/src/sidepanel/SidePanel.tsx
+++ b/apps/extension/src/sidepanel/SidePanel.tsx
@@ -18,13 +18,18 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   DEFAULT_API_BASE,
   PRODUCTION_API_BASE,
+  clearAuthState,
+  connectAuth,
   readApiBase,
+  refreshAuthState,
   publishAnnotation,
   readActiveTabContext,
+  readAuthState,
   readCaptureDraft,
   readPendingCapture,
   saveApiBase,
   saveCaptureDraft,
+  type AuthState,
   type CaptureDraft,
   type PublishAnnotationResult,
   type PageCaptureContext
@@ -54,6 +59,8 @@ export function SidePanel() {
   const [pageContext, setPageContext] = useState<PageCaptureContext | null>(null);
   const [apiBaseUrl, setApiBaseUrl] = useState("");
   const [settingsStatus, setSettingsStatus] = useState<string | null>(null);
+  const [authState, setAuthState] = useState<AuthState>({ token: null, user: null });
+  const [authStatus, setAuthStatus] = useState<string | null>(null);
   const [savedDraft, setSavedDraft] = useState<CaptureDraft | null>(null);
   const [draftStatus, setDraftStatus] = useState<string | null>(null);
   const [publishedAnnotation, setPublishedAnnotation] = useState<PublishAnnotationResult["annotation"] | null>(
@@ -94,6 +101,8 @@ export function SidePanel() {
   useEffect(() => {
     void readApiBase().then(setApiBaseUrl);
     void readCaptureDraft().then(setSavedDraft);
+    void readAuthState().then(setAuthState);
+    void refreshAuthState().then(setAuthState);
   }, []);
 
   function parseTimeInput(value: string): number {
@@ -186,6 +195,24 @@ export function SidePanel() {
     const nextApiBase = await saveApiBase(apiBaseUrl);
     setApiBaseUrl(nextApiBase);
     setSettingsStatus("Saved.");
+  }
+
+  async function connectAccount(provider: "google" | "x") {
+    setAuthStatus(`Starting ${provider === "google" ? "Google" : "X"} sign-in...`);
+    setError(null);
+    try {
+      const next = await connectAuth(provider);
+      setAuthState(next);
+      setAuthStatus(next.user ? `Signed in as @${next.user.handle}.` : "Signed in.");
+    } catch {
+      setAuthStatus("Sign-in is not configured yet. You can still publish to the public demo feed.");
+    }
+  }
+
+  async function disconnectAccount() {
+    await clearAuthState();
+    setAuthState({ token: null, user: null });
+    setAuthStatus("Signed out.");
   }
 
   async function saveDraft() {
@@ -337,6 +364,28 @@ export function SidePanel() {
             Save settings
           </Button>
           {settingsStatus ? <span>{settingsStatus}</span> : null}
+
+          <div className="account-panel">
+            <div>
+              <strong>{authState.user ? `@${authState.user.handle}` : "Account"}</strong>
+              <p>{authState.user ? authState.user.display_name : "Connect before publishing as yourself."}</p>
+            </div>
+            {authState.token ? (
+              <Button tone="secondary" type="button" onClick={() => void disconnectAccount()}>
+                Sign out
+              </Button>
+            ) : (
+              <div className="account-actions">
+                <Button tone="secondary" type="button" onClick={() => void connectAccount("google")}>
+                  Sign in with Google
+                </Button>
+                <Button tone="secondary" type="button" onClick={() => void connectAccount("x")}>
+                  Sign in with X
+                </Button>
+              </div>
+            )}
+            {authStatus ? <span>{authStatus}</span> : null}
+          </div>
         </section>
       ) : mode === "drafts" ? (
         <section className="draft-pane">
@@ -390,7 +439,7 @@ export function SidePanel() {
         {error ? <p className="sidepanel-error">{error}</p> : null}
         <div className="sync-row">
           <UserCircle size={16} aria-hidden="true" />
-          <span>Signed out: production publishes use the demo API author until extension OAuth handoff lands.</span>
+          <span>{authState.user ? `Publishing as @${authState.user.handle}` : "Signed out: publish uses the demo author."}</span>
         </div>
         <Button tone="primary" onClick={publish} disabled={status === "publishing"}>
           <Send size={16} aria-hidden="true" />

--- a/apps/extension/src/sidepanel/api.test.ts
+++ b/apps/extension/src/sidepanel/api.test.ts
@@ -2,10 +2,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { fixtures, type AnnotationResource } from "@annotated/contracts";
 import {
   PRODUCTION_API_BASE,
+  clearAuthState,
+  connectAuth,
   publishAnnotation,
   readApiBase,
+  readAuthState,
   readCaptureDraft,
   readPendingCapture,
+  refreshAuthState,
   saveApiBase,
   saveCaptureDraft
 } from "./api";
@@ -24,15 +28,24 @@ function annotationResponse(id: string): Response {
 
 function stubChromeStorage(initialValues: Record<string, unknown> = {}) {
   const storage = new Map<string, unknown>(Object.entries(initialValues));
+  const readKey = (key: string) => ({ [key]: storage.get(key) });
+  const readKeys = (keys: string[]) => Object.fromEntries(keys.map((key) => [key, storage.get(key)]));
   vi.stubGlobal("chrome", {
+    runtime: {
+      getURL: vi.fn((path: string) => `chrome-extension://extension-id/${path}`)
+    },
+    identity: {
+      launchWebAuthFlow: vi.fn(async () => "chrome-extension://extension-id/sidepanel.html?auth=1")
+    },
     storage: {
       local: {
-        get: vi.fn(async (key: string) => ({ [key]: storage.get(key) })),
+        get: vi.fn(async (key: string | string[]) => (Array.isArray(key) ? readKeys(key) : readKey(key))),
         set: vi.fn(async (value: Record<string, unknown>) => {
           Object.entries(value).forEach(([key, nextValue]) => storage.set(key, nextValue));
         }),
-        remove: vi.fn(async (key: string) => {
-          storage.delete(key);
+        remove: vi.fn(async (key: string | string[]) => {
+          const keys = Array.isArray(key) ? key : [key];
+          keys.forEach((item) => storage.delete(item));
         })
       }
     }
@@ -244,6 +257,104 @@ describe("extension publish API", () => {
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
       `${PRODUCTION_API_BASE}/api/annotations`
     );
+  });
+
+  it("sends the extension bearer token when publishing as a connected account", async () => {
+    stubChromeStorage({
+      authToken: "ext_connected"
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(annotationResponse("ann_auth"));
+
+    await publishAnnotation({
+      context: {
+        source_url: "https://example.com/article",
+        title: "Example article",
+        selection_text: "Selected text"
+      },
+      commentary: "Authenticated extension publish.",
+      captureKind: "text"
+    });
+
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(request.headers).toMatchObject({
+      Authorization: "Bearer ext_connected"
+    });
+  });
+
+  it("connects through Chrome identity, stores the handoff token, and refreshes the profile", async () => {
+    const storage = stubChromeStorage();
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ authorization_url: "https://accounts.google.com/o/oauth2/v2/auth" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: "ext_token", token_type: "Bearer" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ user: { id: "usr_oauth", handle: "mira", display_name: "Mira OAuth" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ user: { id: "usr_oauth", handle: "mira", display_name: "Mira OAuth" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        })
+      );
+
+    await expect(connectAuth("google")).resolves.toMatchObject({
+      token: "ext_token",
+      user: {
+        handle: "mira"
+      }
+    });
+    expect(storage.get("authToken")).toBe("ext_token");
+    expect(chrome.identity.launchWebAuthFlow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interactive: true
+      })
+    );
+
+    await expect(refreshAuthState()).resolves.toMatchObject({
+      token: "ext_token",
+      user: {
+        handle: "mira"
+      }
+    });
+    expect(fetchMock.mock.calls[3]?.[1]).toMatchObject({
+      headers: {
+        Authorization: "Bearer ext_token"
+      }
+    });
+  });
+
+  it("clears the stored extension token when profile refresh fails", async () => {
+    const storage = stubChromeStorage({
+      authToken: "ext_expired",
+      authUser: { id: "usr_oauth", handle: "mira", display_name: "Mira OAuth" }
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("expired", { status: 401 }));
+
+    await expect(refreshAuthState()).resolves.toEqual({
+      token: null,
+      user: null
+    });
+    expect(storage.has("authToken")).toBe(false);
+    expect(storage.has("authUser")).toBe(false);
+
+    await clearAuthState();
+    await expect(readAuthState()).resolves.toEqual({
+      token: null,
+      user: null
+    });
   });
 
   it("clears stale pending selected-text captures after reading them once", async () => {

--- a/apps/extension/src/sidepanel/api.ts
+++ b/apps/extension/src/sidepanel/api.ts
@@ -9,6 +9,8 @@ import {
 export const DEFAULT_API_BASE = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8787";
 export const PRODUCTION_API_BASE = "https://annotated-canvas-api.jaybhagat841.workers.dev";
 const API_BASE_STORAGE_KEY = "apiBaseUrl";
+const AUTH_TOKEN_STORAGE_KEY = "authToken";
+const AUTH_USER_STORAGE_KEY = "authUser";
 const PENDING_CAPTURE_STORAGE_KEY = "pendingCapture";
 const CAPTURE_DRAFT_STORAGE_KEY = "captureDraft";
 
@@ -49,6 +51,18 @@ export interface PublishAnnotationResult {
   annotation: AnnotationResource;
 }
 
+export interface ExtensionUser {
+  id: string;
+  handle: string;
+  display_name: string;
+  avatar_url?: string;
+}
+
+export interface AuthState {
+  token: string | null;
+  user: ExtensionUser | null;
+}
+
 function normalizeApiBase(value: string): string {
   return value.trim().replace(/\/+$/, "");
 }
@@ -73,6 +87,104 @@ export async function saveApiBase(value: string): Promise<string> {
     });
   }
   return normalized || DEFAULT_API_BASE;
+}
+
+export async function readAuthState(): Promise<AuthState> {
+  if (!globalThis.chrome?.storage?.local) return { token: null, user: null };
+  const result = await chrome.storage.local.get([AUTH_TOKEN_STORAGE_KEY, AUTH_USER_STORAGE_KEY]);
+  return {
+    token: typeof result[AUTH_TOKEN_STORAGE_KEY] === "string" ? result[AUTH_TOKEN_STORAGE_KEY] : null,
+    user: (result[AUTH_USER_STORAGE_KEY] as ExtensionUser | undefined) ?? null
+  };
+}
+
+export async function clearAuthState(): Promise<void> {
+  if (globalThis.chrome?.storage?.local) {
+    await chrome.storage.local.remove([AUTH_TOKEN_STORAGE_KEY, AUTH_USER_STORAGE_KEY]);
+  }
+}
+
+async function authHeaders(): Promise<Record<string, string>> {
+  const { token } = await readAuthState();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function refreshAuthState(): Promise<AuthState> {
+  const apiBase = await readApiBase();
+  const current = await readAuthState();
+  if (!current.token) return current;
+
+  const response = await fetch(`${apiBase}/api/me`, {
+    headers: {
+      Authorization: `Bearer ${current.token}`
+    }
+  });
+  if (!response.ok) {
+    await clearAuthState();
+    return { token: null, user: null };
+  }
+
+  const payload = (await response.json()) as { user?: ExtensionUser };
+  const next = {
+    token: current.token,
+    user: payload.user ?? current.user
+  };
+  if (globalThis.chrome?.storage?.local) {
+    await chrome.storage.local.set({
+      [AUTH_USER_STORAGE_KEY]: next.user
+    });
+  }
+  return next;
+}
+
+export async function connectAuth(provider: "google" | "x" = "google"): Promise<AuthState> {
+  const apiBase = await readApiBase();
+  const returnTo = typeof globalThis.chrome?.runtime?.getURL === "function"
+    ? chrome.runtime.getURL("sidepanel.html?auth=1")
+    : globalThis.location.href;
+  const search = new URLSearchParams({ return_to: returnTo });
+  const start = await fetch(`${apiBase}/api/auth/${provider}/start?${search.toString()}`, {
+    credentials: "include"
+  });
+  if (!start.ok) throw new Error("auth_start_failed");
+  const startPayload = (await start.json()) as { authorization_url?: string };
+  if (!startPayload.authorization_url) throw new Error("auth_start_failed");
+
+  if (typeof globalThis.chrome?.identity?.launchWebAuthFlow === "function") {
+    await chrome.identity.launchWebAuthFlow({
+      url: startPayload.authorization_url,
+      interactive: true
+    });
+  } else {
+    globalThis.open(startPayload.authorization_url, "_blank", "noopener,noreferrer");
+  }
+
+  const tokenResponse = await fetch(`${apiBase}/api/auth/extension-token`, {
+    method: "POST",
+    credentials: "include"
+  });
+  if (!tokenResponse.ok) throw new Error("extension_token_failed");
+  const tokenPayload = (await tokenResponse.json()) as { token?: string };
+  if (!tokenPayload.token) throw new Error("extension_token_failed");
+
+  const meResponse = await fetch(`${apiBase}/api/me`, {
+    headers: {
+      Authorization: `Bearer ${tokenPayload.token}`
+    }
+  });
+  if (!meResponse.ok) throw new Error("auth_profile_failed");
+  const mePayload = (await meResponse.json()) as { user?: ExtensionUser };
+  const next = {
+    token: tokenPayload.token,
+    user: mePayload.user ?? null
+  };
+  if (globalThis.chrome?.storage?.local) {
+    await chrome.storage.local.set({
+      [AUTH_TOKEN_STORAGE_KEY]: next.token,
+      [AUTH_USER_STORAGE_KEY]: next.user
+    });
+  }
+  return next;
 }
 
 export async function readActiveTabContext(): Promise<PageCaptureContext | null> {
@@ -130,7 +242,8 @@ async function uploadAudioCommentary(audioBlob: Blob): Promise<string> {
   const response = await fetch(`${apiBase}/api/uploads/audio-commentary`, {
     method: "POST",
     headers: {
-      "Content-Type": audioBlob.type || "audio/webm"
+      "Content-Type": audioBlob.type || "audio/webm",
+      ...(await authHeaders())
     },
     body: audioBlob
   });
@@ -199,7 +312,8 @@ export async function publishAnnotation(options: PublishOptions): Promise<Publis
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "Idempotency-Key": `extension-${Date.now()}`
+      "Idempotency-Key": `extension-${Date.now()}`,
+      ...(await authHeaders())
     },
     body: JSON.stringify(payload)
   });

--- a/apps/extension/src/sidepanel/sidepanel.css
+++ b/apps/extension/src/sidepanel/sidepanel.css
@@ -358,6 +358,24 @@ body {
   justify-self: start;
 }
 
+.account-panel {
+  border-top: 1px solid var(--ac-border);
+  padding-top: 14px;
+  display: grid;
+  gap: 10px;
+}
+
+.account-panel strong {
+  color: var(--ac-text);
+  font-size: 13px;
+}
+
+.account-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .sidepanel-footer {
   border-top: 1px solid var(--ac-border);
   padding: 14px 20px 18px;


### PR DESCRIPTION
## Summary
- accept short-lived extension bearer tokens in API auth checks and `/api/me`
- attribute extension-created annotations to the authenticated OAuth user instead of the demo user when a valid handoff token is present
- add side panel account connect/disconnect UI using Chrome identity, extension-token exchange, stored bearer token, and profile refresh
- allow `chrome-extension://` return URLs for OAuth handoff while keeping web return URLs pinned to `APP_ORIGIN`

## Verification
- `npm test -- apps/api/src/app.test.ts apps/extension/src/sidepanel/api.test.ts`
- `npm run typecheck`
- `npm run build`

## Production dependency
- Production still fails closed until Cloudflare Worker secrets are installed for `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `X_CLIENT_ID`, and `X_CLIENT_SECRET`.

Relates to #24
