### PR TITLE
Guard legacy OAuth routes in Clerk mode

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -715,6 +715,45 @@ describe("API router regression coverage", () => {
     expect(payload.error.details.missing).toContain("CLERK_SECRET_KEY");
   });
 
+  it("fails legacy provider start closed in Clerk mode instead of returning a bare callback URL", async () => {
+    const response = await handleRequest(
+      request("/api/auth/google/start?return_to=/signup"),
+      {
+        ...env,
+        AUTH_MODE: "clerk"
+      },
+      { repository, jobs }
+    );
+    const payload = await body(response);
+
+    expect(response.status).toBe(503);
+    expect(payload.error.code).toBe("auth_not_configured");
+    expect(payload.error.details).toMatchObject({
+      strategy: "clerk",
+      provider: "google"
+    });
+    expect(payload.error.details.missing).toContain("VITE_CLERK_PUBLISHABLE_KEY");
+    expect(payload.authorization_url).toBeUndefined();
+  });
+
+  it("redirects stale legacy OAuth callbacks back to signup in Clerk mode", async () => {
+    const response = await handleRequest(
+      request("/api/auth/x/callback"),
+      {
+        ...env,
+        AUTH_MODE: "clerk",
+        APP_ORIGIN: "https://annotated-canvas.pages.dev"
+      },
+      { repository, jobs }
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "https://annotated-canvas.pages.dev/signup?auth_error=clerk_required&provider=x"
+    );
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
   it("deletes the session on logout when session KV is available", async () => {
     const sessionKv = createSessionKv({
       "session:ses_valid": JSON.stringify({

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -243,6 +243,27 @@ function oauthConfigError(env: Env, request: Request, provider: AuthProvider, mi
   }, request);
 }
 
+function clerkSetupError(env: Env, request: Request, provider: AuthProvider): Response {
+  return error(env, 503, "auth_not_configured", "Sign-in is handled by Clerk and is not configured in this client build.", {
+    provider,
+    strategy: "clerk",
+    missing: ["VITE_CLERK_PUBLISHABLE_KEY"]
+  }, request);
+}
+
+function legacyOAuthCallbackRedirect(env: Env, provider: AuthProvider): Response {
+  const redirectUrl = new URL("/signup", normalizeAppOrigin(env.APP_ORIGIN));
+  redirectUrl.searchParams.set("auth_error", "clerk_required");
+  redirectUrl.searchParams.set("provider", provider);
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: redirectUrl.toString(),
+      "Cache-Control": "no-store"
+    }
+  });
+}
+
 function parseCookie(request: Request, name: string): string | null {
   const cookieHeader = request.headers.get("Cookie");
   if (!cookieHeader) return null;
@@ -684,6 +705,10 @@ export async function handleRequest(request: Request, env: Env, services = makeS
     const returnTo = resolveReturnTo(env, url.searchParams.get("return_to"));
     const state = `state_${crypto.randomUUID()}`;
     const mode = authMode(env);
+    if (mode === "clerk") {
+      return clerkSetupError(env, request, provider.data);
+    }
+
     const credentials = getProviderCredentials(env, provider.data);
     const missing = mode === "oauth" ? missingOAuthConfig(env, provider.data) : [];
     if (missing.length > 0) {
@@ -725,6 +750,10 @@ export async function handleRequest(request: Request, env: Env, services = makeS
     const provider = AuthProviderSchema.safeParse(authCallbackMatch[1]);
     if (!provider.success) {
       return error(env, 400, "unsupported_auth_provider", "Auth provider must be x or google.");
+    }
+
+    if (authMode(env) === "clerk") {
+      return legacyOAuthCallbackRedirect(env, provider.data);
     }
 
     const state = url.searchParams.get("state");


### PR DESCRIPTION
## Summary
- fail legacy `/api/auth/:provider/start` closed in `AUTH_MODE=clerk` instead of returning a bare callback URL
- redirect stale legacy `/api/auth/:provider/callback` requests back to `/signup?auth_error=clerk_required&provider=...` in Clerk mode
- add regression coverage for the Clerk-mode start/callback guard

## Production evidence
- Current production deploy run `25253328222` is commit `b3655234eef8489d9f7e73d80f1927359349394f`.
- `GET /api/auth/google/callback` and `GET /api/auth/x/callback` reproduce `400 oauth_state_required` on that build.

## Verification
- `npm test -- apps/api/src/app.test.ts`
- `npm run typecheck`
- `npm run build`

Closes #52
