### PR TITLE
Hide auth buttons until Clerk is configured

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -100,7 +100,8 @@ describe("Annotated web shell", () => {
     expect(screen.getByRole("heading", { name: /browse first/i })).toBeInTheDocument();
     expect(screen.getByAltText(/selected text ready to publish/i)).toBeInTheDocument();
     expect(screen.getByAltText(/published selected-text annotation/i)).toBeInTheDocument();
-    expect(screen.getByText("Sign in with Google")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign-in setup pending" })).toBeDisabled();
+    expect(screen.getByRole("status")).toHaveTextContent("Sign-in setup is pending.");
     expect(screen.getByText("View public feed")).toBeInTheDocument();
     expect(screen.getByText("Extension install guide")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /see the feed, load the extension/i })).toBeInTheDocument();
@@ -118,78 +119,24 @@ describe("Annotated web shell", () => {
     expect(screen.getByText("Signed out")).toBeInTheDocument();
   });
 
-  it("opens provider choice from header and renders missing-provider errors inline", async () => {
+  it("opens signup from header and shows setup-pending auth instead of dead provider buttons", async () => {
     const user = userEvent.setup();
-    const fetchMock = vi.mocked(fetch);
-    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
-      const url = requestUrl(input);
-
-      if (url.includes("/api/me")) {
-        return jsonResponse({ user: null });
-      }
-
-      if (url.includes("/api/auth/google/start")) {
-        return jsonResponse(
-          {
-            error: {
-              code: "auth_provider_not_configured",
-              message: "Google sign-in is not configured."
-            }
-          },
-          503
-        );
-      }
-
-      return defaultFetch(input);
-    });
 
     renderAt("/");
 
     await user.click(screen.getByRole("button", { name: "Sign in" }));
     expect(screen.getByRole("heading", { name: /save the exact moment/i })).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: /sign in with google/i }));
-
-    await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("/api/auth/google/start?"), {
-        method: "GET"
-      });
-    });
-    expect(screen.getByRole("alert")).toHaveTextContent(/google sign-in is not configured/i);
-    expect(screen.getByRole("alert")).toHaveTextContent(/load the unpacked extension/i);
+    expect(screen.queryByRole("button", { name: /sign in with google/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /sign in with x/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign-in setup pending" })).toBeDisabled();
     expect(screen.getByText("Install extension")).toBeInTheDocument();
   });
 
-  it("starts X auth through fetch and follows the returned authorization URL", async () => {
-    const user = userEvent.setup();
-    const fetchMock = vi.mocked(fetch);
-    let authorizationUrl = "";
-
-    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
-      const url = requestUrl(input);
-
-      if (url.includes("/api/me")) {
-        return jsonResponse({ user: null });
-      }
-
-      if (url.includes("/api/auth/x/start")) {
-        return jsonResponse({ authorization_url: authorizationUrl });
-      }
-
-      return defaultFetch(input);
-    });
-
+  it("does not call legacy provider start routes in a no-Clerk client build", async () => {
     renderAt("/home");
-    authorizationUrl = new URL("/oauth/x", window.location.href).toString();
 
-    await user.click(screen.getByRole("button", { name: /sign in with x/i }));
-
-    await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("/api/auth/x/start?"), {
-        method: "GET"
-      });
-      expect(window.location.href).toBe(authorizationUrl);
-    });
+    expect(fetch).not.toHaveBeenCalledWith(expect.stringContaining("/api/auth/x/start?"), expect.anything());
+    expect(fetch).not.toHaveBeenCalledWith(expect.stringContaining("/api/auth/google/start?"), expect.anything());
   });
 
   it("renders the bounty URL capture composer on the feed", () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import { type FormEvent, useEffect, useMemo, useState } from "react";
 import {
   API_BASE,
   ApiRequestError,
+  CLERK_CLIENT_CONFIGURED,
   loadCurrentViewer,
   loadAnnotation,
   loadComments,
@@ -155,6 +156,10 @@ export function App() {
 
   function authErrorMessage(error: unknown, provider: AuthProvider) {
     if (error instanceof ApiRequestError) {
+      if (error.code === "clerk_client_not_configured") {
+        return "Sign-in setup is pending.";
+      }
+
       const configuredError =
         error.code?.includes("not_configured") || error.message.toLowerCase().includes("configured");
       return configuredError ? `${providerLabel(provider)} sign-in is not configured yet.` : error.message;
@@ -359,22 +364,30 @@ export function App() {
               </figure>
             </section>
             <div className="marketing-actions">
-              <button
-                type="button"
-                className="marketing-button marketing-button--primary"
-                onClick={() => void handleAuthStart("google")}
-                disabled={authPending !== null}
-              >
-                {authPending === "google" ? "Starting Google..." : "Sign in with Google"}
-              </button>
-              <button
-                type="button"
-                className="marketing-button"
-                onClick={() => void handleAuthStart("x")}
-                disabled={authPending !== null}
-              >
-                {authPending === "x" ? "Starting X..." : "Sign in with X"}
-              </button>
+              {CLERK_CLIENT_CONFIGURED ? (
+                <>
+                  <button
+                    type="button"
+                    className="marketing-button marketing-button--primary"
+                    onClick={() => void handleAuthStart("google")}
+                    disabled={authPending !== null}
+                  >
+                    {authPending === "google" ? "Starting Google..." : "Sign in with Google"}
+                  </button>
+                  <button
+                    type="button"
+                    className="marketing-button"
+                    onClick={() => void handleAuthStart("x")}
+                    disabled={authPending !== null}
+                  >
+                    {authPending === "x" ? "Starting X..." : "Sign in with X"}
+                  </button>
+                </>
+              ) : (
+                <button type="button" className="marketing-button marketing-button--primary" disabled>
+                  Sign-in setup pending
+                </button>
+              )}
               <button type="button" onClick={() => navigate("feed")}>
                 View public feed
               </button>
@@ -386,6 +399,20 @@ export function App() {
               <div className="auth-recovery" role="alert">
                 <strong>{authError}</strong>
                 <p>For review, load the unpacked extension and use the production API in Settings.</p>
+                <div className="auth-recovery__actions">
+                  <button type="button" onClick={() => navigate("feed")}>
+                    View feed
+                  </button>
+                  <a href={REVIEWER_GUIDE_URL} target="_blank" rel="noreferrer">
+                    Install extension
+                  </a>
+                </div>
+              </div>
+            ) : null}
+            {!CLERK_CLIENT_CONFIGURED ? (
+              <div className="auth-recovery" role="status">
+                <strong>Sign-in setup is pending.</strong>
+                <p>Public feed, permalink, extension capture, comments, claims, and audio storage are available while Clerk keys are installed.</p>
                 <div className="auth-recovery__actions">
                   <button type="button" onClick={() => navigate("feed")}>
                     View feed

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -11,6 +11,7 @@ import {
 
 export const API_BASE =
   import.meta.env.VITE_API_BASE_URL ?? (import.meta.env.DEV ? "http://localhost:8787" : "");
+export const CLERK_CLIENT_CONFIGURED = Boolean(import.meta.env.VITE_CLERK_PUBLISHABLE_KEY);
 const shouldFetch = import.meta.env.MODE !== "test";
 
 export type AuthProvider = "google" | "x";
@@ -95,6 +96,14 @@ export async function startAuth(provider: AuthProvider, returnTo: string): Promi
   if (authRedirectHandler) {
     await authRedirectHandler(provider, returnTo);
     return "";
+  }
+
+  if (!CLERK_CLIENT_CONFIGURED) {
+    throw new ApiRequestError(
+      503,
+      "Sign-in setup is pending. Clerk keys are not installed for this deployment.",
+      "clerk_client_not_configured"
+    );
   }
 
   const search = new URLSearchParams({ return_to: returnTo });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -308,7 +308,7 @@
 }
 
 .marketing-actions button:disabled {
-  cursor: wait;
+  cursor: not-allowed;
   opacity: 0.72;
 }
 


### PR DESCRIPTION
## Summary
- hide active Google/X sign-in buttons when the web build has no `VITE_CLERK_PUBLISHABLE_KEY`
- show a clear `Sign-in setup pending` state with feed/install actions that still work
- make `startAuth()` fail locally with `clerk_client_not_configured` instead of calling legacy provider routes in a no-Clerk build
- update web tests for the no-Clerk production state

## Verification
- `npm test -- apps/web/src/App.test.tsx`
- `npm run typecheck`
- `npm run build`

Closes #54
Relates to #50
